### PR TITLE
Support configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,13 +6,16 @@ The repro can then be used as the basis of a bug report or a starting point for 
 
 ## Usage
 
-First, build your project with `--generateTrace traceDir`
+First, build your project with `--generateTrace traceDir`.  This will create a new `traceDir` directory with paired trace and types files.
 
-For a sorted list of compilation hot-spots, run `npx analyze-trace traceDir`
+For a sorted list of compilation hot-spots, run `npx analyze-trace traceDir`.
+Pass `--help` to learn more about configuration options.
+For best results, run the analyzer on a machine where the paths in the trace file(s) resolve correctly.
 
-For a simplified view of a types file (useful when investigating an individual trace), run `npx simplify-trace-types traceDir\types.json output_path`
+For a simplified view of a types file (useful when investigating an individual trace), run `npx simplify-trace-types traceDir\types.json output_path`.
+Note that the resulting file is for human consumption and should not be passed to the analyzer (i.e. don't clobber the original).
 
-To pretty-print individual types from a types file (faster than processing the entire file), run `npx print-types traceDir\types.json id+`
+To pretty-print individual types from a types file (faster than processing the entire file), run `npx print-types traceDir\types.json id+`.
 
 ## Trademarks
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@typescript/analyze-trace",
   "author": "Microsoft Corp.",
   "homepage": "https://github.com/microsoft/typescript-analyze-trace#readme",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "license": "MIT",
   "description": "Analyze the output of tsc --generatetrace",
   "keywords": [

--- a/src/analyze-trace-dir.ts
+++ b/src/analyze-trace-dir.ts
@@ -156,7 +156,7 @@ async function analyzeProject(project: Project): Promise<ProjectResult> {
     }
 
     return new Promise<ProjectResult>(resolve => {
-        const child = cp.fork(path.join(__dirname, "analyze-trace-file"), args, { stdio: "pipe", env: { FORCE_COLOR: '1' } });
+        const child = cp.fork(path.join(__dirname, "analyze-trace-file"), args, { stdio: "pipe", env: { FORCE_COLOR: process.env["FORCE_COLOR"] ?? '1' } });
 
         let stdout = "";
         let stderr = "";

--- a/src/analyze-trace-dir.ts
+++ b/src/analyze-trace-dir.ts
@@ -9,7 +9,7 @@ import path = require("path");
 import plimit = require("p-limit");
 import yargs = require("yargs");
 
-import { commandLineOptions, checkCommandLineOptions } from "./analyze-trace-options";
+import { commandLineOptions, checkCommandLineOptions, pushCommandLineOptions } from "./analyze-trace-options";
 
 const argv = yargs(process.argv.slice(2))
     .command("$0 <traceDir>", "Preprocess tracing type dumps", yargs => yargs
@@ -156,7 +156,7 @@ async function analyzeProject(project: Project): Promise<ProjectResult> {
     if (await isFile(project.typesPath)) {
         args.push(project.typesPath);
     }
-    args.push("--force-millis", `${argv.forceMillis}`, "--skip-millis", `${argv.skipMillis}`, argv.color ? "--color" : "--no-color");
+    pushCommandLineOptions(args, argv);
 
     return new Promise<ProjectResult>(resolve => {
         const child = cp.fork(path.join(__dirname, "analyze-trace-file"), args, { stdio: "pipe" });

--- a/src/analyze-trace-dir.ts
+++ b/src/analyze-trace-dir.ts
@@ -156,10 +156,10 @@ async function analyzeProject(project: Project): Promise<ProjectResult> {
     if (await isFile(project.typesPath)) {
         args.push(project.typesPath);
     }
-    args.push("--force-millis", `${argv.forceMillis}`, "--skip-millis", `${argv.skipMillis}`);
+    args.push("--force-millis", `${argv.forceMillis}`, "--skip-millis", `${argv.skipMillis}`, argv.color ? "--color" : "--no-color");
 
     return new Promise<ProjectResult>(resolve => {
-        const child = cp.fork(path.join(__dirname, "analyze-trace-file"), args, { stdio: "pipe", env: { FORCE_COLOR: process.env["FORCE_COLOR"] ?? '1' } });
+        const child = cp.fork(path.join(__dirname, "analyze-trace-file"), args, { stdio: "pipe" });
 
         let stdout = "";
         let stderr = "";

--- a/src/analyze-trace-dir.ts
+++ b/src/analyze-trace-dir.ts
@@ -17,7 +17,7 @@ const argv = yargs(process.argv.slice(2))
         .options(commandLineOptions)
         .check(checkCommandLineOptions)
         .help("h").alias("h", "help")
-        .strict().skipValidation)
+        .strict())
     .argv;
 
 const limit = plimit(os.cpus().length);

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -19,7 +19,7 @@ const argv = yargs(process.argv.slice(2))
         .options(commandLineOptions)
         .check(checkCommandLineOptions)
         .help("h").alias("h", "help")
-        .strict().skipValidation)
+        .strict())
     .argv;
 
 const Parser = require("jsonparse");

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -1,38 +1,53 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-if (process.argv.length !== 3 && process.argv.length != 4) {
-    const path = require("path");
-    console.error(`Usage: ${path.basename(process.argv[0])} ${path.basename(process.argv[1])} trace_path [type_path]`);
-    process.exit(1);
-}
-
 import { assert } from "console";
 import chalk = require("chalk");
 import treeify = require("treeify");
 import fs = require("fs");
 import path = require("path");
+import yargs = require("yargs");
 
 import getTypeTree = require("./get-type-tree");
 import normalizePositions = require("./normalize-positions");
 
+const argv = yargs(process.argv.slice(2))
+    .command("$0 <tracePath> [typesPath]", "Preprocess tracing type dumps", yargs => yargs
+        .positional("tracePath", { type: "string", desc: "Trace file to read", coerce: throwIfNotFile })
+        .positional("typesPath", { type: "string", desc: "Corresponding types file", coerce: throwIfNotFile })
+        .options({
+            "forceMillis": {
+                alias: ["forcemillis", "force-millis"],
+                describe: "Events of at least this duration (in milliseconds) will reported unconditionally",
+                type: "number",
+                default: 500,
+
+            },
+            "skipMillis": {
+                alias: ["skipmillis", "skip-millis"],
+                describe: "Events of less than this duration (in milliseconds) will suppressed unconditionally",
+                type: "number",
+                default: 100,
+
+            },
+        })
+        .check(argv => {
+            if (argv.forceMillis < argv.skipMillis) {
+                throw new Error("forceMillis cannot be less than skipMillis")
+            }
+            return true;
+        })
+        .help("h").alias("h", "help")
+        .strict().skipValidation)
+    .argv;
+
 const Parser = require("jsonparse");
 
-const tracePath = process.argv[2];
-const typesPath = process.argv[3];
+const tracePath = argv.tracePath!;
+const typesPath = argv.typesPath;
 
-if (!fs.existsSync(tracePath)) {
-    console.error(`${tracePath} does not exist`);
-    process.exit(2);
-}
-
-if (typesPath && !fs.existsSync(typesPath)) {
-    console.error(`${typesPath} does not exist`);
-    process.exit(3);
-}
-
-const thresholdDuration = 5E5; // microseconds
-const minDuration = 1E5; // microseconds
+const thresholdDuration = argv.forceMillis * 1000; // microseconds
+const minDuration = argv.skipMillis * 1000; // microseconds
 const minPercentage = 0.6;
 
 main().catch(err => console.error(`Internal Error: ${err.message}\n${err.stack}`));
@@ -290,7 +305,7 @@ let typesCache: undefined | readonly any[];
 async function getTypes(): Promise<readonly any[]> {
     if (!typesCache) {
         try {
-            const json = await fs.promises.readFile(typesPath, { encoding: "utf-8" });
+            const json = await fs.promises.readFile(typesPath!, { encoding: "utf-8" });
             typesCache = JSON.parse(json);
         }
         catch (e: any) {
@@ -432,4 +447,11 @@ function unmangleCamelCase(name: string) {
 
 function getLineCharMapKey(line: number, char: number) {
     return `${line},${char}`;
+}
+
+function throwIfNotFile(path: string): string {
+    if (!fs.existsSync(path) || !fs.statSync(path)?.isFile()) {
+        throw new Error(`${path} is not a file`);
+    }
+    return path;
 }

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -10,33 +10,14 @@ import yargs = require("yargs");
 
 import getTypeTree = require("./get-type-tree");
 import normalizePositions = require("./normalize-positions");
+import { commandLineOptions, checkCommandLineOptions } from "./analyze-trace-options";
 
 const argv = yargs(process.argv.slice(2))
     .command("$0 <tracePath> [typesPath]", "Preprocess tracing type dumps", yargs => yargs
         .positional("tracePath", { type: "string", desc: "Trace file to read", coerce: throwIfNotFile })
         .positional("typesPath", { type: "string", desc: "Corresponding types file", coerce: throwIfNotFile })
-        .options({
-            "forceMillis": {
-                alias: ["forcemillis", "force-millis"],
-                describe: "Events of at least this duration (in milliseconds) will reported unconditionally",
-                type: "number",
-                default: 500,
-
-            },
-            "skipMillis": {
-                alias: ["skipmillis", "skip-millis"],
-                describe: "Events of less than this duration (in milliseconds) will suppressed unconditionally",
-                type: "number",
-                default: 100,
-
-            },
-        })
-        .check(argv => {
-            if (argv.forceMillis < argv.skipMillis) {
-                throw new Error("forceMillis cannot be less than skipMillis")
-            }
-            return true;
-        })
+        .options(commandLineOptions)
+        .check(checkCommandLineOptions)
         .help("h").alias("h", "help")
         .strict().skipValidation)
     .argv;

--- a/src/analyze-trace-options.ts
+++ b/src/analyze-trace-options.ts
@@ -14,12 +14,18 @@ export const commandLineOptions = {
         type: "number",
         default: 100,
     },
+    "color": {
+        describe: "Color the output to make it easier to read",
+        type: "boolean",
+        default: true,
+    },
 } as const;
 
 // Replicating the type inference in yargs would be excessive
 type Argv = {
     forceMillis: number,
-    skipMillis: number
+    skipMillis: number,
+    color: boolean,
 };
 
 export function checkCommandLineOptions(argv: Argv): true {

--- a/src/analyze-trace-options.ts
+++ b/src/analyze-trace-options.ts
@@ -1,0 +1,30 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+export const commandLineOptions = {
+    "forceMillis": {
+        alias: ["forcemillis", "force-millis"],
+        describe: "Events of at least this duration (in milliseconds) will reported unconditionally",
+        type: "number",
+        default: 500,
+    },
+    "skipMillis": {
+        alias: ["skipmillis", "skip-millis"],
+        describe: "Events of less than this duration (in milliseconds) will suppressed unconditionally",
+        type: "number",
+        default: 100,
+    },
+} as const;
+
+// Replicating the type inference in yargs would be excessive
+type Argv = {
+    forceMillis: number,
+    skipMillis: number
+};
+
+export function checkCommandLineOptions(argv: Argv): true {
+    if (argv.forceMillis < argv.skipMillis) {
+        throw new Error("forceMillis cannot be less than skipMillis")
+    }
+    return true;
+}

--- a/src/analyze-trace-options.ts
+++ b/src/analyze-trace-options.ts
@@ -34,3 +34,10 @@ export function checkCommandLineOptions(argv: Argv): true {
     }
     return true;
 }
+
+export function pushCommandLineOptions(array: string[], argv: Argv): void {
+    array.push(
+        "--force-millis", `${argv.forceMillis}`,
+        "--skip-millis", `${argv.skipMillis}`,
+        argv.color ? "--color" : "--no-color");
+}


### PR DESCRIPTION
Adopt yargs and add support for setting thresholds.  Avoid clobbering chalk env vars.

Fixes #8 