### PR TITLE
Report on actionable emit hotspots

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@typescript/analyze-trace",
   "author": "Microsoft Corp.",
   "homepage": "https://github.com/microsoft/typescript-analyze-trace#readme",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "description": "Analyze the output of tsc --generatetrace",
   "keywords": [

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -342,9 +342,9 @@ async function makePrintableTree(curr: EventSpan, currentFile: string | undefine
             // TODO (https://github.com/microsoft/typescript-analyze-trace/issues/2)
             // case "findSourceFile":
             //     return `Load file ${event.args!.fileName}`;
-            // TODO (https://github.com/microsoft/typescript-analyze-trace/issues/3)
-            // case "emit":
-            //     return `Emit`;
+            case "emitDeclarationFileOrBundle":
+                const dtsPath = event.args.declarationFilePath;
+                return dtsPath && `Emit typings file ${formatPath(dtsPath)}`;
             case "checkSourceFile":
                 return `Check file ${formatPath(currentFile!)}`;
             case "structuredTypeRelatedTo":

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -360,7 +360,7 @@ async function makePrintableTree(curr: EventSpan, currentFile: string | undefine
                         // Directly modifying childTree is pretty hacky
                         childTree[`Consider adding \`${chalk.cyan(`import ${chalk.cyan(imp)}`)}\` which is used in ${count} places`] = {};
                     }
-                    return `Emit typings file ${formatPath(dtsPath)}`;
+                    return `Emit declarations file ${formatPath(dtsPath)}`;
                 }
                 catch {
                     return undefined;

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -11,6 +11,7 @@ import yargs = require("yargs");
 import getTypeTree = require("./get-type-tree");
 import normalizePositions = require("./normalize-positions");
 import { commandLineOptions, checkCommandLineOptions } from "./analyze-trace-options";
+import countImportExpressions = require("./count-import-expressions");
 
 const argv = yargs(process.argv.slice(2))
     .command("$0 <tracePath> [typesPath]", "Preprocess tracing type dumps", yargs => yargs
@@ -30,6 +31,7 @@ const typesPath = argv.typesPath;
 const thresholdDuration = argv.forceMillis * 1000; // microseconds
 const minDuration = argv.skipMillis * 1000; // microseconds
 const minPercentage = 0.6;
+const importExpressionThreshold = 10;
 
 main().catch(err => console.error(`Internal Error: ${err.message}\n${err.stack}`));
 
@@ -326,7 +328,7 @@ async function makePrintableTree(curr: EventSpan, currentFile: string | undefine
     }
 
     if (curr.event) {
-        const eventStr = eventToString();
+        const eventStr = await eventToString();
         if (eventStr) {
             let result = {};
             result[`${eventStr} (${Math.round((curr.end - curr.start) / 1000)}ms)`] = childTree;
@@ -336,7 +338,7 @@ async function makePrintableTree(curr: EventSpan, currentFile: string | undefine
 
     return childTree;
 
-    function eventToString(): string | undefined {
+    async function eventToString(): Promise<string | undefined> {
         const event = curr.event!;
         switch (event.name) {
             // TODO (https://github.com/microsoft/typescript-analyze-trace/issues/2)
@@ -344,7 +346,25 @@ async function makePrintableTree(curr: EventSpan, currentFile: string | undefine
             //     return `Load file ${event.args!.fileName}`;
             case "emitDeclarationFileOrBundle":
                 const dtsPath = event.args.declarationFilePath;
-                return dtsPath && `Emit typings file ${formatPath(dtsPath)}`;
+                if (!dtsPath || !fs.existsSync(dtsPath)) {
+                    return undefined;
+                }
+                try {
+                    const sourceStream = fs.createReadStream(dtsPath, { encoding: "utf-8" });
+                    const frequency = await countImportExpressions(sourceStream);
+                    const sorted = Array.from(frequency.entries()).sort(([import1, count1], [import2, count2]) => count2 - count1 || import1.localeCompare(import2)).filter(([_, count]) => count >= importExpressionThreshold);
+                    if (sorted.length === 0) {
+                        return undefined;
+                    }
+                    for (const [imp, count] of sorted) {
+                        // Directly modifying childTree is pretty hacky
+                        childTree[`Consider adding \`${chalk.cyan(`import ${chalk.cyan(imp)}`)}\` which is used in ${count} places`] = {};
+                    }
+                    return `Emit typings file ${formatPath(dtsPath)}`;
+                }
+                catch {
+                    return undefined;
+                }
             case "checkSourceFile":
                 return `Check file ${formatPath(currentFile!)}`;
             case "structuredTypeRelatedTo":

--- a/src/count-import-expressions.ts
+++ b/src/count-import-expressions.ts
@@ -1,0 +1,81 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+import stream = require("stream");
+import TriviaStateMachine = require("./trivia-state-machine");
+
+/**
+ * @param stream A stream of string chunks with respect to which `positions` should be normalized.
+ * @returns A frequency table of imported module names.
+ */
+function countImportExpressions(stream: stream.Readable): Promise<Map<string, number>> {
+    return new Promise<Map<string, number>>((resolve, reject) => {
+        let prevCh = -1;
+
+        stream.on("error", err => reject(err));
+
+        // The actual event handling is in onChar and onEof below.
+        // These handlers provided a simplified current- and next-char view.
+        stream.on("data", chunk => {
+            const text = chunk as string;
+            const length = text.length;
+            for (let i = 0; i < length; i++) {
+                const ch = text.charCodeAt(i);
+                if (prevCh >= 0) {
+                    onChar(prevCh, ch);
+                }
+                prevCh = ch;
+            }
+        });
+
+        stream.on("close", () => {
+            if (prevCh >= 0) {
+                onChar(prevCh, -1);
+            }
+
+            onEof();
+        });
+
+        const target = "import("; // tsc doesn't emit a space before the lparen
+        let targetPos = 0;
+
+        const buf: number[] = [];
+
+        const frequency = new Map<string, number>();
+
+        let stateMachine = TriviaStateMachine.create();
+
+        function onChar(ch: number, nextCh: number) {
+            const { charKind } = stateMachine.step(ch, nextCh);
+
+            if (targetPos === target.length) {
+                if (charKind === "string") {
+                    buf.push(ch);
+                }
+                else {
+                    const name = String.fromCharCode(...buf);
+
+                    if (!frequency.has(name)) {
+                        frequency.set(name, 0);
+                    }
+                    frequency.set(name, frequency.get(name)! + 1);
+
+                    targetPos = 0;
+                    buf.length = 0;
+                }
+            }
+            else if (charKind === "code" && ch === target.charCodeAt(targetPos)) {
+                targetPos++;
+            }
+            else {
+                targetPos = 0;
+            }
+        }
+
+        function onEof() {
+            resolve(frequency);
+        }
+    });
+}
+
+export = countImportExpressions;

--- a/src/normalize-positions.ts
+++ b/src/normalize-positions.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import stream = require("stream");
+import TriviaStateMachine = require("./trivia-state-machine");
 
 namespace normalizePositions {
     export type LineChar = readonly [line: number, char: number];
@@ -67,53 +68,6 @@ function normalizePositions(stream: stream.Readable, positions: ReadonlyArray<nu
             onEof();
         });
 
-        const code_CarriageReturn = "\r".charCodeAt(0);
-        const code_NewLine = "\n".charCodeAt(0);
-        const code_Space = " ".charCodeAt(0);
-        const code_Tab = "\t".charCodeAt(0);
-        const code_Slash = "/".charCodeAt(0);
-        const code_Backslash = "\\".charCodeAt(0);
-        const code_Star = "*".charCodeAt(0);
-        const code_Hash = "#".charCodeAt(0);
-        const code_Bang = "!".charCodeAt(0);
-        const code_SingleQuote = "'".charCodeAt(0);
-        const code_DoubleQuote = "\"".charCodeAt(0);
-        const code_OpenBrace = "{".charCodeAt(0);
-        const code_CloseBrace = "}".charCodeAt(0);
-        const code_OpenBracket = "[".charCodeAt(0);
-        const code_CloseBracket = "]".charCodeAt(0);
-        const code_Backtick = "`".charCodeAt(0);
-        const code_Dollar = "$".charCodeAt(0);
-
-        const enum State {
-            Uninitialized,
-            Default,
-            StartSingleLineComment,
-            SingleLineComment,
-            StartMultiLineComment,
-            MultiLineComment,
-            EndMultiLineComment,
-            StartShebangComment,
-            ShebangComment,
-            SingleQuoteString,
-            SingleQuoteStringEscapeBackslash,
-            SingleQuoteStringEscapeQuote,
-            DoubleQuoteString,
-            DoubleQuoteStringEscapeBackslash,
-            DoubleQuoteStringEscapeQuote,
-            TemplateString,
-            TemplateStringEscapeBackslash,
-            TemplateStringEscapeQuote,
-            StartExpressionHole,
-            Regex,
-            RegexEscapeBackslash,
-            RegexEscapeSlash,
-            RegexEscapeOpenBracket,
-            CharClass,
-            CharClassEscapeBackslash,
-            CharClassEscapeCloseBracket,
-        }
-
         // We partition the positions because the varieties
         // cannot be sorted with respect to each other.
         const fixedOffsetWrappers: PositionWrapper[] = []; // Don't skip trivia
@@ -165,248 +119,14 @@ function normalizePositions(stream: stream.Readable, positions: ReadonlyArray<nu
 
         let currOffset = 0;
         let currLineChar: MutableLineChar = [1, 1];
-        let state = State.Default;
-        let braceDepth = 0;
-        let templateStringBraceDepthStack: number[] = [];
+        let stateMachine = TriviaStateMachine.create();
 
         function onChar(ch: number, nextCh: number) {
-            let nextState = State.Uninitialized;;
-            let wrapLine = false;
-            switch (ch) {
-                case code_CarriageReturn:
-                    if (nextCh === code_NewLine) {
-                        if (state === State.ShebangComment ||
-                            state === State.SingleLineComment ||
-                            // Cases below are for error recovery
-                            state === State.SingleQuoteString ||
-                            state === State.DoubleQuoteString ||
-                            state === State.Regex ||
-                            state === State.CharClass) {
-                            state = State.Default;
-                        }
-                        break;
-                    }
-                // Fall through
-                case code_NewLine:
-                    wrapLine = true;
-                    if (state === State.ShebangComment ||
-                        state === State.SingleLineComment) {
-                        state = State.Default;
-                    }
-                    else if (state === State.SingleQuoteString || // Error recovery
-                        state === State.DoubleQuoteString) { // Error recovery
-                        state = State.Default;
-                    }
-                    break;
-
-                case code_Slash:
-                    if (state === State.Default) {
-                        if (nextCh === code_Slash) {
-                            state = State.StartSingleLineComment;
-                        }
-                        else if (nextCh === code_Star) {
-                            // It seems like there might technically be a corner case where this is the beginning of an invalid regex
-                            state = State.StartMultiLineComment;
-                        }
-                        else {
-                            state = State.Regex;
-                        }
-                    }
-                    else if (state === State.StartSingleLineComment) {
-                        state = State.SingleLineComment;
-                    }
-                    else if (state === State.EndMultiLineComment) {
-                        nextState = State.Default;
-                    }
-                    else if (state === State.Regex) {
-                        nextState = State.Default;
-                    }
-                    else if (state === State.RegexEscapeSlash) {
-                        nextState = State.Regex;
-                    }
-                    break;
-
-                case code_Star:
-                    if (state === State.StartMultiLineComment) {
-                        state = State.MultiLineComment;
-                    }
-                    else if (state === State.MultiLineComment) {
-                        if (nextCh === code_Slash) {
-                            state = State.EndMultiLineComment;
-                        }
-                    }
-                    break;
-
-                case code_Hash:
-                    if (currOffset === 0 && state === State.Default && nextCh === code_Bang) {
-                        state = State.StartShebangComment;
-                    }
-                    break;
-
-                case code_Bang:
-                    if (state === State.StartShebangComment) {
-                        state = State.ShebangComment;
-                    }
-                    break;
-
-                case code_SingleQuote:
-                    if (state === State.Default) {
-                        state = State.SingleQuoteString;
-                    }
-                    else if (state === State.SingleQuoteStringEscapeQuote) {
-                        nextState = State.SingleQuoteString;
-                    }
-                    else if (state === State.SingleQuoteString) {
-                        nextState = State.Default;
-                    }
-                    break;
-
-                case code_DoubleQuote:
-                    if (state === State.Default) {
-                        state = State.DoubleQuoteString;
-                    }
-                    else if (state === State.DoubleQuoteStringEscapeQuote) {
-                        nextState = State.DoubleQuoteString;
-                    }
-                    else if (state === State.DoubleQuoteString) {
-                        nextState = State.Default;
-                    }
-                    break;
-
-                case code_Backtick:
-                    if (state === State.Default) {
-                        state = State.TemplateString;
-                    }
-                    else if (state === State.TemplateStringEscapeQuote) {
-                        nextState = State.TemplateString;
-                    }
-                    else if (state === State.TemplateString) {
-                        nextState = State.Default;
-                    }
-                    break;
-
-                case code_Backslash:
-                    if (state === State.SingleQuoteString) {
-                        if (nextCh === code_SingleQuote) {
-                            state = State.SingleQuoteStringEscapeQuote;
-                        }
-                        else if (nextCh === code_Backslash) {
-                            state = State.SingleQuoteStringEscapeBackslash;
-                        }
-                    }
-                    else if (state === State.DoubleQuoteString) {
-                        if (nextCh === code_DoubleQuote) {
-                            state = State.DoubleQuoteStringEscapeQuote;
-                        }
-                        else if (nextCh === code_Backslash) {
-                            state = State.DoubleQuoteStringEscapeBackslash;
-                        }
-                    }
-                    else if (state === State.TemplateString) {
-                        if (nextCh === code_Backtick) {
-                            state = State.TemplateStringEscapeQuote;
-                        }
-                        else if (nextCh === code_Backslash) {
-                            state = State.TemplateStringEscapeBackslash;
-                        }
-                    }
-                    else if (state === State.Regex) {
-                        if (nextCh === code_OpenBracket) {
-                            state = State.RegexEscapeOpenBracket;
-                        }
-                        else if (nextCh === code_Slash) {
-                            state = State.RegexEscapeSlash;
-                        }
-                        else if (nextCh === code_Backslash) {
-                            state = State.RegexEscapeBackslash;
-                        }
-                    }
-                    else if (state === State.CharClass) {
-                        if (nextCh === code_CloseBracket) {
-                            state = State.CharClassEscapeCloseBracket;
-                        }
-                        else if (nextCh === code_Backslash) {
-                            state = State.CharClassEscapeBackslash;
-                        }
-                    }
-                    else if (state === State.SingleQuoteStringEscapeBackslash) {
-                        nextState = State.SingleQuoteString;
-                    }
-                    else if (state === State.DoubleQuoteStringEscapeBackslash) {
-                        nextState = State.DoubleQuoteString;
-                    }
-                    else if (state === State.TemplateStringEscapeBackslash) {
-                        nextState = State.TemplateString;
-                    }
-                    else if (state === State.RegexEscapeBackslash) {
-                        nextState = State.Regex;
-                    }
-                    else if (state === State.CharClassEscapeBackslash) {
-                        nextState = State.CharClass;
-                    }
-                    break;
-
-                case code_Dollar:
-                    if (state === State.TemplateString && nextCh === code_OpenBrace) {
-                        state = State.StartExpressionHole;
-                    }
-                    break;
-
-                case code_OpenBrace:
-                    if (state === State.Default) {
-                        braceDepth++;
-                    }
-                    else if (state === State.StartExpressionHole) {
-                        templateStringBraceDepthStack.push(braceDepth);
-                        nextState = State.Default;
-                    }
-                    break;
-
-                case code_CloseBrace:
-                    if (templateStringBraceDepthStack.length && braceDepth === templateStringBraceDepthStack[templateStringBraceDepthStack.length - 1]) {
-                        templateStringBraceDepthStack.pop();
-                        state = State.TemplateString;
-                    }
-                    else if (state === State.Default && braceDepth > 0) { // Error recovery
-                        braceDepth--;
-                    }
-                    break;
-
-                case code_OpenBracket:
-                    if (state === State.RegexEscapeOpenBracket) {
-                        nextState = State.Regex;
-                    }
-                    else if (state === State.Regex) {
-                        state = State.CharClass;
-                    }
-                    break;
-
-                case code_CloseBracket:
-                    if (state === State.CharClassEscapeCloseBracket) {
-                        nextState = State.CharClass;
-                    }
-                    else if (state === State.CharClass) {
-                        nextState = State.Regex;
-                    }
-                    break;
-            }
-
-            const isTrivia =
-                state === State.StartSingleLineComment ||
-                state === State.SingleLineComment ||
-                state === State.StartMultiLineComment ||
-                state === State.MultiLineComment ||
-                state === State.EndMultiLineComment ||
-                state === State.StartShebangComment ||
-                state === State.ShebangComment ||
-                ch === code_Space ||
-                ch === code_Tab ||
-                ch === code_NewLine ||
-                ch === code_CarriageReturn ||
-                /^\s$/.test(String.fromCharCode(ch));
+            const { charKind, wrapLine } = stateMachine.step(ch, nextCh);
+            const isTrivia = charKind === "comment" || charKind === "whitespace";
 
             // This is handy when debugging
-            // console.error(`${currOffset}\t${/^[a-zA-Z0-9!@#$%^&*()[\]{}\\/;':"<,>.?`~+=_\-]$/.test(String.fromCharCode(ch)) ? String.fromCharCode(ch) : "0x" + ch.toString(16)}\t(${currLineChar[0]},${currLineChar[1]})\t${isTrivia ? "Triv" : "Not"}\tS${state}\tB${braceDepth}`);
+            // console.error(`${currOffset}\t${/^[a-zA-Z0-9!@#$%^&*()[\]{}\\/;':"<,>.?`~+=_\-]$/.test(String.fromCharCode(ch)) ? String.fromCharCode(ch) : "0x" + ch.toString(16)}\t(${currLineChar[0]},${currLineChar[1]})\t${charKind}`);
 
             for (; fixedOffsetWrappersPos < fixedOffsetWrappers.length && compareOffsets(fixedOffsetWrappers[fixedOffsetWrappersPos].offset!, currOffset) <= 0; fixedOffsetWrappersPos++) {
                 fixedOffsetWrappers[fixedOffsetWrappersPos].offset = currOffset;
@@ -438,10 +158,6 @@ function normalizePositions(stream: stream.Readable, positions: ReadonlyArray<nu
             }
             else {
                 currLineChar[1]++;
-            }
-
-            if (nextState !== State.Uninitialized) {
-                state = nextState;
             }
 
             // TODO (https://github.com/microsoft/typescript-analyze-trace/issues/4)

--- a/src/trivia-state-machine.ts
+++ b/src/trivia-state-machine.ts
@@ -1,0 +1,351 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+const code_CarriageReturn = "\r".charCodeAt(0);
+const code_NewLine = "\n".charCodeAt(0);
+const code_Space = " ".charCodeAt(0);
+const code_Tab = "\t".charCodeAt(0);
+const code_Slash = "/".charCodeAt(0);
+const code_Backslash = "\\".charCodeAt(0);
+const code_Star = "*".charCodeAt(0);
+const code_Hash = "#".charCodeAt(0);
+const code_Bang = "!".charCodeAt(0);
+const code_SingleQuote = "'".charCodeAt(0);
+const code_DoubleQuote = "\"".charCodeAt(0);
+const code_OpenBrace = "{".charCodeAt(0);
+const code_CloseBrace = "}".charCodeAt(0);
+const code_OpenBracket = "[".charCodeAt(0);
+const code_CloseBracket = "]".charCodeAt(0);
+const code_Backtick = "`".charCodeAt(0);
+const code_Dollar = "$".charCodeAt(0);
+
+const enum State {
+    Uninitialized,
+    Default,
+    StartSingleLineComment,
+    SingleLineComment,
+    StartMultiLineComment,
+    MultiLineComment,
+    EndMultiLineComment,
+    StartShebangComment,
+    ShebangComment,
+    SingleQuoteString,
+    SingleQuoteStringEscapeBackslash,
+    SingleQuoteStringEscapeQuote,
+    DoubleQuoteString,
+    DoubleQuoteStringEscapeBackslash,
+    DoubleQuoteStringEscapeQuote,
+    TemplateString,
+    TemplateStringEscapeBackslash,
+    TemplateStringEscapeQuote,
+    StartExpressionHole,
+    Regex,
+    RegexEscapeBackslash,
+    RegexEscapeSlash,
+    RegexEscapeOpenBracket,
+    CharClass,
+    CharClassEscapeBackslash,
+    CharClassEscapeCloseBracket,
+}
+
+export type CharKind =
+    | "whitespace"
+    | "comment"
+    | "string"
+    | "regex"
+    | "code"
+    ;
+
+interface StepResult {
+    charKind: CharKind;
+    wrapLine: boolean;
+}
+
+export interface StateMachine {
+    step(ch: number, nextCh: number): StepResult;
+}
+
+export function create(): StateMachine {
+    let state = State.Default;
+    let braceDepth = 0;
+    let templateStringBraceDepthStack: number[] = [];
+    let isBOF = true;
+
+    function step(ch: number, nextCh: number): StepResult {
+        let nextStateId = State.Uninitialized;;
+        let wrapLine = false;
+        switch (ch) {
+            case code_CarriageReturn:
+                if (nextCh === code_NewLine) {
+                    if (state === State.ShebangComment ||
+                        state === State.SingleLineComment ||
+                        // Cases below are for error recovery
+                        state === State.SingleQuoteString ||
+                        state === State.DoubleQuoteString ||
+                        state === State.Regex ||
+                        state === State.CharClass) {
+                        state = State.Default;
+                    }
+                    break;
+                }
+                // Fall through
+            case code_NewLine:
+                wrapLine = true;
+                if (state === State.ShebangComment ||
+                    state === State.SingleLineComment) {
+                    state = State.Default;
+                }
+                else if (state === State.SingleQuoteString || // Error recovery
+                    state === State.DoubleQuoteString) { // Error recovery
+                    state = State.Default;
+                }
+                break;
+
+            case code_Slash:
+                if (state === State.Default) {
+                    if (nextCh === code_Slash) {
+                        state = State.StartSingleLineComment;
+                    }
+                    else if (nextCh === code_Star) {
+                        // It seems like there might technically be a corner case where this is the beginning of an invalid regex
+                        state = State.StartMultiLineComment;
+                    }
+                    else {
+                        // TODO (https://github.com/microsoft/typescript-analyze-trace/issues/14): this is too aggressive - it will catch division
+                        state = State.Regex;
+                    }
+                }
+                else if (state === State.StartSingleLineComment) {
+                    state = State.SingleLineComment;
+                }
+                else if (state === State.EndMultiLineComment) {
+                    nextStateId = State.Default;
+                }
+                else if (state === State.Regex) {
+                    nextStateId = State.Default;
+                }
+                else if (state === State.RegexEscapeSlash) {
+                    nextStateId = State.Regex;
+                }
+                break;
+
+            case code_Star:
+                if (state === State.StartMultiLineComment) {
+                    state = State.MultiLineComment;
+                }
+                else if (state === State.MultiLineComment) {
+                    if (nextCh === code_Slash) {
+                        state = State.EndMultiLineComment;
+                    }
+                }
+                break;
+
+            case code_Hash:
+                if (isBOF && state === State.Default && nextCh === code_Bang) {
+                    state = State.StartShebangComment;
+                }
+                break;
+
+            case code_Bang:
+                if (state === State.StartShebangComment) {
+                    state = State.ShebangComment;
+                }
+                break;
+
+            case code_SingleQuote:
+                if (state === State.Default) {
+                    state = State.SingleQuoteString;
+                }
+                else if (state === State.SingleQuoteStringEscapeQuote) {
+                    nextStateId = State.SingleQuoteString;
+                }
+                else if (state === State.SingleQuoteString) {
+                    nextStateId = State.Default;
+                }
+                break;
+
+            case code_DoubleQuote:
+                if (state === State.Default) {
+                    state = State.DoubleQuoteString;
+                }
+                else if (state === State.DoubleQuoteStringEscapeQuote) {
+                    nextStateId = State.DoubleQuoteString;
+                }
+                else if (state === State.DoubleQuoteString) {
+                    nextStateId = State.Default;
+                }
+                break;
+
+            case code_Backtick:
+                if (state === State.Default) {
+                    state = State.TemplateString;
+                }
+                else if (state === State.TemplateStringEscapeQuote) {
+                    nextStateId = State.TemplateString;
+                }
+                else if (state === State.TemplateString) {
+                    nextStateId = State.Default;
+                }
+                break;
+
+            case code_Backslash:
+                if (state === State.SingleQuoteString) {
+                    if (nextCh === code_SingleQuote) {
+                        state = State.SingleQuoteStringEscapeQuote;
+                    }
+                    else if (nextCh === code_Backslash) {
+                        state = State.SingleQuoteStringEscapeBackslash;
+                    }
+                }
+                else if (state === State.DoubleQuoteString) {
+                    if (nextCh === code_DoubleQuote) {
+                        state = State.DoubleQuoteStringEscapeQuote;
+                    }
+                    else if (nextCh === code_Backslash) {
+                        state = State.DoubleQuoteStringEscapeBackslash;
+                    }
+                }
+                else if (state === State.TemplateString) {
+                    if (nextCh === code_Backtick) {
+                        state = State.TemplateStringEscapeQuote;
+                    }
+                    else if (nextCh === code_Backslash) {
+                        state = State.TemplateStringEscapeBackslash;
+                    }
+                }
+                else if (state === State.Regex) {
+                    if (nextCh === code_OpenBracket) {
+                        state = State.RegexEscapeOpenBracket;
+                    }
+                    else if (nextCh === code_Slash) {
+                        state = State.RegexEscapeSlash;
+                    }
+                    else if (nextCh === code_Backslash) {
+                        state = State.RegexEscapeBackslash;
+                    }
+                }
+                else if (state === State.CharClass) {
+                    if (nextCh === code_CloseBracket) {
+                        state = State.CharClassEscapeCloseBracket;
+                    }
+                    else if (nextCh === code_Backslash) {
+                        state = State.CharClassEscapeBackslash;
+                    }
+                }
+                else if (state === State.SingleQuoteStringEscapeBackslash) {
+                    nextStateId = State.SingleQuoteString;
+                }
+                else if (state === State.DoubleQuoteStringEscapeBackslash) {
+                    nextStateId = State.DoubleQuoteString;
+                }
+                else if (state === State.TemplateStringEscapeBackslash) {
+                    nextStateId = State.TemplateString;
+                }
+                else if (state === State.RegexEscapeBackslash) {
+                    nextStateId = State.Regex;
+                }
+                else if (state === State.CharClassEscapeBackslash) {
+                    nextStateId = State.CharClass;
+                }
+                break;
+
+            case code_Dollar:
+                if (state === State.TemplateString && nextCh === code_OpenBrace) {
+                    state = State.StartExpressionHole;
+                }
+                break;
+
+            case code_OpenBrace:
+                if (state === State.Default) {
+                    braceDepth++;
+                }
+                else if (state === State.StartExpressionHole) {
+                    templateStringBraceDepthStack.push(braceDepth);
+                    nextStateId = State.Default;
+                }
+                break;
+
+            case code_CloseBrace:
+                if (templateStringBraceDepthStack.length && braceDepth === templateStringBraceDepthStack[templateStringBraceDepthStack.length - 1]) {
+                    templateStringBraceDepthStack.pop();
+                    state = State.TemplateString;
+                }
+                else if (state === State.Default && braceDepth > 0) { // Error recovery
+                    braceDepth--;
+                }
+                break;
+
+            case code_OpenBracket:
+                if (state === State.RegexEscapeOpenBracket) {
+                    nextStateId = State.Regex;
+                }
+                else if (state === State.Regex) {
+                    state = State.CharClass;
+                }
+                break;
+
+            case code_CloseBracket:
+                if (state === State.CharClassEscapeCloseBracket) {
+                    nextStateId = State.CharClass;
+                }
+                else if (state === State.CharClass) {
+                    nextStateId = State.Regex;
+                }
+                break;
+        }
+
+        let charKind: CharKind;
+
+        switch (state) {
+            case State.StartSingleLineComment:
+            case State.SingleLineComment:
+            case State.StartMultiLineComment:
+            case State.MultiLineComment:
+            case State.EndMultiLineComment:
+            case State.StartShebangComment:
+            case State.ShebangComment:
+                charKind = "comment";
+                break;
+            case State.SingleQuoteString:
+            case State.SingleQuoteStringEscapeBackslash:
+            case State.SingleQuoteStringEscapeQuote:
+            case State.DoubleQuoteString:
+            case State.DoubleQuoteStringEscapeBackslash:
+            case State.DoubleQuoteStringEscapeQuote:
+            case State.TemplateString:
+            case State.TemplateStringEscapeBackslash:
+            case State.TemplateStringEscapeQuote:
+            case State.StartExpressionHole:
+                charKind = "string";
+                break;
+            case State.Regex:
+            case State.RegexEscapeBackslash:
+            case State.RegexEscapeSlash:
+            case State.RegexEscapeOpenBracket:
+            case State.CharClass:
+            case State.CharClassEscapeBackslash:
+            case State.CharClassEscapeCloseBracket:
+                charKind = "regex";
+                break;
+            default:
+                const isWhitespace =
+                    ch === code_Space ||
+                    ch === code_Tab ||
+                    ch === code_NewLine ||
+                    ch === code_CarriageReturn ||
+                    /^\s$/.test(String.fromCharCode(ch));
+                charKind = isWhitespace ? "whitespace" : "code";
+                break;
+        }
+
+        if (nextStateId !== State.Uninitialized) {
+            state = nextStateId;
+        }
+
+        isBOF = false;
+
+        return { charKind, wrapLine };
+    }
+
+    return { step };
+}


### PR DESCRIPTION
After looking at lots of traces it appears that JS emit is nearly always proportional (with a small constant) to file size (even with down-levelling), so flagging JS files that took a long time to emit rarely does anything beyond identifying large input files.

Declaration emit, on the other hand, is much less directly related to input size.  So far, the most important factor we've found for disproportionately slow declaration emit is the presence of a lot of import expressions in the output.  This PR attempts to flag such instances by searching slow-to-emit declaration files (if present) for import expressions.

Fixes #3 (until we find some other cause of disproportionate slowdown).