### PR TITLE
Detect npm packages imported from multiple locations

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@typescript/analyze-trace",
   "author": "Microsoft Corp.",
   "homepage": "https://github.com/microsoft/typescript-analyze-trace#readme",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "license": "MIT",
   "description": "Analyze the output of tsc --generatetrace",
   "keywords": [


### PR DESCRIPTION
This is best-effort since particularly fast file loads will be dropped during trace production, but presumably at least one file will make it per interesting package.

If the original source is available, also report the version numbers.