### PR TITLE
Add --expand-types flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@typescript/analyze-trace",
   "author": "Microsoft Corp.",
   "homepage": "https://github.com/microsoft/typescript-analyze-trace#readme",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "license": "MIT",
   "description": "Analyze the output of tsc --generatetrace",
   "keywords": [

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -236,7 +236,7 @@ async function printDuplicateNodeModules(nodeModulePaths: Map<string, string[]>)
 }
 
 async function printHotStacks(root: EventSpan): Promise<boolean> {
-    if (typesPath) {
+    if (typesPath && argv.expandTypes) {
         await addTypeTrees(root);
     }
     const positionMap = await getNormalizedPositions(root);

--- a/src/analyze-trace-options.ts
+++ b/src/analyze-trace-options.ts
@@ -14,6 +14,12 @@ export const commandLineOptions = {
         type: "number",
         default: 100,
     },
+    "expandTypes": {
+        alias: ["expandtypes", "expand-types"],
+        describe: "Color the output to make it easier to read",
+        type: "boolean",
+        default: true,
+    },
     "color": {
         describe: "Color the output to make it easier to read",
         type: "boolean",
@@ -25,6 +31,7 @@ export const commandLineOptions = {
 type Argv = {
     forceMillis: number,
     skipMillis: number,
+    expandTypes: boolean,
     color: boolean,
 };
 
@@ -39,5 +46,6 @@ export function pushCommandLineOptions(array: string[], argv: Argv): void {
     array.push(
         "--force-millis", `${argv.forceMillis}`,
         "--skip-millis", `${argv.skipMillis}`,
+        argv.expandTypes ? "--expand-types" : "--no-expand-types",
         argv.color ? "--color" : "--no-color");
 }


### PR DESCRIPTION
So that types can optionally be suppressed (e.g. if there are many large unions).