### PR TITLE
Add `jsonparse` as a dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@typescript/analyze-trace",
-  "version": "0.1.0",
+  "version": "0.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@typescript/analyze-trace",
-      "version": "0.1.0",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
+        "jsonparse": "^1.3.1",
         "jsonstream-next": "^3.0.0",
         "p-limit": "^3.1.0",
         "split2": "^3.2.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
+    "jsonparse": "^1.3.1",
     "jsonstream-next": "^3.0.0",
     "p-limit": "^3.1.0",
     "split2": "^3.2.2",


### PR DESCRIPTION
`jsonparse` is used in `analyze-trace-file.ts` but is not declared as a dependency.

Yarn >=2 with PnP throws an error when running `yarn dlx @typescript/analyse-trace trace-dir` because it is stricter with dependencies.

```
Error: @typescript/analyze-trace tried to access jsonparse, but it isn't declared in its dependencies; this makes the require call ambiguous and unsound.

Required package: jsonparse
```