### PR TITLE
Use exit package rather than process.exit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "@typescript/analyze-trace",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@typescript/analyze-trace",
-      "version": "0.8.0",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
+        "exit": "^0.1.2",
         "jsonparse": "^1.3.1",
         "jsonstream-next": "^3.0.0",
         "p-limit": "^3.1.0",
@@ -140,6 +141,14 @@
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ==",
+      "engines": {
+        "node": ">= 0.8.0"
       }
     },
     "node_modules/get-caller-file": {
@@ -485,6 +494,11 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
       "integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+    },
+    "exit": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
+      "integrity": "sha512-Zk/eNKV2zbjpKzrsQ+n1G6poVbErQxJ0LBOJXaKZ1EViLzH+hrLu9cdXI4zw9dBQJslwBEpbQ2P1oS7nDxs6jQ=="
     },
     "get-caller-file": {
       "version": "2.0.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@typescript/analyze-trace",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@typescript/analyze-trace",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@typescript/analyze-trace",
   "author": "Microsoft Corp.",
   "homepage": "https://github.com/microsoft/typescript-analyze-trace#readme",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "license": "MIT",
   "description": "Analyze the output of tsc --generatetrace",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
+    "exit": "^0.1.2",
     "jsonparse": "^1.3.1",
     "jsonstream-next": "^3.0.0",
     "p-limit": "^3.1.0",

--- a/src/analyze-trace-dir.ts
+++ b/src/analyze-trace-dir.ts
@@ -22,7 +22,8 @@ const argv = yargs(process.argv.slice(2))
         .strict())
     .argv;
 
-const limit = plimit(os.cpus().length);
+// Try to leave one core free
+const limit = plimit(Math.max(1, os.cpus().length - 1));
 
 const traceDir = argv.traceDir!;
 

--- a/src/analyze-trace-dir.ts
+++ b/src/analyze-trace-dir.ts
@@ -26,7 +26,7 @@ const limit = plimit(os.cpus().length);
 const traceDir = argv.traceDir!;
 
 main().then(
-    code => process.exit(code),
+    code => process.exitCode = code,
     err => {
         console.error(`Internal error: ${err.message}`);
         process.exit(2);

--- a/src/analyze-trace-dir.ts
+++ b/src/analyze-trace-dir.ts
@@ -6,6 +6,7 @@ import fs = require("fs");
 import os = require("os");
 import path = require("path");
 
+import exit = require("exit");
 import plimit = require("p-limit");
 import yargs = require("yargs");
 
@@ -29,7 +30,7 @@ main().then(
     code => process.exitCode = code,
     err => {
         console.error(`Internal error: ${err.message}`);
-        process.exit(2);
+        exit(2);
     });
 
 interface Project {

--- a/src/analyze-trace-dir.ts
+++ b/src/analyze-trace-dir.ts
@@ -27,10 +27,10 @@ const limit = plimit(Math.max(1, os.cpus().length - 1));
 
 const traceDir = argv.traceDir!;
 
-main().then(
-    code => process.exitCode = code,
-    err => {
-        console.error(`Internal error: ${err.message}`);
+main()
+    .then(code => exit(code))
+    .catch(err => {
+        console.error(`Internal Error: ${err.message}`)
         exit(2);
     });
 

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 import fs = require("fs");
+import exit = require("exit");
 import yargs = require("yargs");
 
 import { commandLineOptions, checkCommandLineOptions } from "./analyze-trace-options";
@@ -32,7 +33,7 @@ const reportHighlights = argv.json ? reportJson : reportText;
 
 reportHighlights(tracePath, argv.expandTypes ? typesPath : undefined, thresholdDuration, minDuration, minPercentage, importExpressionThreshold).then(found => process.exitCode = found ? 0 : 1).catch(err => {
     console.error(`Internal Error: ${err.message}\n${err.stack}`)
-    process.exit(2);
+    exit(2);
 });
 
 function throwIfNotFile(path: string): string {

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -31,7 +31,9 @@ const importExpressionThreshold = 10;
 
 const reportHighlights = argv.json ? reportJson : reportText;
 
-reportHighlights(tracePath, argv.expandTypes ? typesPath : undefined, thresholdDuration, minDuration, minPercentage, importExpressionThreshold).then(found => process.exitCode = found ? 0 : 1).catch(err => {
+reportHighlights(tracePath, argv.expandTypes ? typesPath : undefined, thresholdDuration, minDuration, minPercentage, importExpressionThreshold)
+  .then(found => exit(found ? 0 : 1))
+  .catch(err => {
     console.error(`Internal Error: ${err.message}\n${err.stack}`)
     exit(2);
 });

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -30,7 +30,7 @@ const importExpressionThreshold = 10;
 
 const reportHighlights = argv.json ? reportJson : reportText;
 
-reportHighlights(tracePath, argv.expandTypes ? typesPath : undefined, thresholdDuration, minDuration, minPercentage, importExpressionThreshold).then(found => process.exit(found ? 0 : 1)).catch(err => {
+reportHighlights(tracePath, argv.expandTypes ? typesPath : undefined, thresholdDuration, minDuration, minPercentage, importExpressionThreshold).then(found => process.exitCode = found ? 0 : 1).catch(err => {
     console.error(`Internal Error: ${err.message}\n${err.stack}`)
     process.exit(2);
 });


### PR DESCRIPTION
It [sounds like](https://nodejs.org/api/process.html#processexitcode) `process.exit` might truncate in-flight I/O, so use `process.exitCode` in non-error scenarios.

(I'm tentatively assuming that a tiny message sent to stdout/stderr immediately before exit will make it to the console.)

Fixes #33