### PR TITLE
stream parse large types files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,11 +24,21 @@
         "simplify-trace-types": "bin/simplify-trace-types"
       },
       "devDependencies": {
+        "@types/jsonstream-next": "^3.0.1",
         "@types/node": "^14.18.5",
         "@types/split2": "^3.2.1",
         "@types/treeify": "^1.0.0",
         "@types/yargs": "^16.0.4",
         "typescript": "^4.5.4"
+      }
+    },
+    "node_modules/@types/jsonstream-next": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonstream-next/-/jsonstream-next-3.0.1.tgz",
+      "integrity": "sha512-lTc4l4EJTYNrnUtDjV4E/6OS7bU4a6zS0hATBVjgnmFy/Hq9p59hTrIPhXkWL17WcJOw/YwIWVPp8Ah3D0kCew==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/node": {
@@ -404,6 +414,15 @@
     }
   },
   "dependencies": {
+    "@types/jsonstream-next": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@types/jsonstream-next/-/jsonstream-next-3.0.1.tgz",
+      "integrity": "sha512-lTc4l4EJTYNrnUtDjV4E/6OS7bU4a6zS0hATBVjgnmFy/Hq9p59hTrIPhXkWL17WcJOw/YwIWVPp8Ah3D0kCew==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/node": {
       "version": "14.18.5",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.5.tgz",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build": "tsc -p src"
   },
   "devDependencies": {
+    "@types/jsonstream-next": "^3.0.1",
     "@types/node": "^14.18.5",
     "@types/split2": "^3.2.1",
     "@types/treeify": "^1.0.0",

--- a/src/analyze-trace-utilities.ts
+++ b/src/analyze-trace-utilities.ts
@@ -157,20 +157,20 @@ export async function getTypes(typesPath: string): Promise<readonly any[]> {
         return new Promise((resolve, reject) => {
             try {
                 const readStream = fs.createReadStream(typesPath, { encoding: "utf-8" });
-                readStream.on('open', () => {
+                readStream.on("open", () => {
                     typesCache = []
                 })
-                readStream.on('end', () => {
+                readStream.on("end", () => {
                     resolve(typesCache!)
                 });
-                readStream.on('error', (e) => {
+                readStream.on("error", (e) => {
                     console.error(`Error reading types file: ${e.message}`);
                     reject()
                 })
 
                 // expects types file to be {object[]}
-                const parser = jsonstream.parse('*')
-                parser.on('data', (data: object) => {
+                const parser = jsonstream.parse("*")
+                parser.on("data", (data: object) => {
                     (typesCache as any[]).push(data);
                 });
 

--- a/src/analyze-trace-utilities.ts
+++ b/src/analyze-trace-utilities.ts
@@ -179,7 +179,7 @@ export async function getTypes(typesPath: string): Promise<readonly any[]> {
         });
     }
 
-    return Promise.resolve(typesCache);
+    return typesCache;
 }
 
 export interface EmittedImport {

--- a/src/analyze-trace-utilities.ts
+++ b/src/analyze-trace-utilities.ts
@@ -8,7 +8,6 @@ import normalizePositions = require("./normalize-positions");
 import simplify = require("./simplify-type");
 import { EventSpan, ParseResult } from "./parse-trace-file";
 
-// @ts-ignore - no types
 import jsonstream = require("jsonstream-next");
 
 export function buildHotPathsTree(parseResult: ParseResult, thresholdDuration: number, minPercentage: number): EventSpan {

--- a/src/analyze-trace-utilities.ts
+++ b/src/analyze-trace-utilities.ts
@@ -155,28 +155,28 @@ let typesCache: undefined | readonly any[];
 export async function getTypes(typesPath: string): Promise<readonly any[]> {
     if (!typesCache) {
         return new Promise((resolve, _reject) => {
-            typesCache = []
+            typesCache = [];
 
             const readStream = fs.createReadStream(typesPath, { encoding: "utf-8" });
             readStream.on("end", () => {
-                resolve(typesCache!)
+                resolve(typesCache!);
             });
-            readStream.on("error", onError)
+            readStream.on("error", onError);
 
             // expects types file to be {object[]}
-            const parser = jsonstream.parse("*")
+            const parser = jsonstream.parse("*");
             parser.on("data", (data: object) => {
                 (typesCache as any[]).push(data);
             });
-            parser.on("error", onError)
+            parser.on("error", onError);
 
-            readStream.pipe(parser)
+            readStream.pipe(parser);
 
             function onError(e: Error) {
                 console.error(`Error reading types file: ${e.message}`);
-                resolve(typesCache!)
+                resolve(typesCache!);
             }
-        })
+        });
     }
 
     return Promise.resolve(typesCache);

--- a/src/simplify-types-file.ts
+++ b/src/simplify-types-file.ts
@@ -10,7 +10,6 @@ import zlib = require("zlib");
 import split = require("split2");
 import yargs = require("yargs");
 
-// @ts-ignore - no types
 import jsonstream = require("jsonstream-next");
 
 import simplifyType = require("./simplify-type");
@@ -49,7 +48,7 @@ async function processFile(processElement: (element: {}) => readonly {}[]) {
     if (args.m) {
         const transform = jsonstream.parse("*");
 
-        const oldFlush: (cb: (err?: Error) => void) => void = transform._flush.bind(transform);
+        const oldFlush = transform._flush.bind(transform);
         const newFlush: typeof oldFlush = cb => {
             return oldFlush(err => {
                 if (err) {


### PR DESCRIPTION
Fixes #9 

I ran into this issue in a monorepo with a types.json trace file of over 600MB. Here's a simple fix for it using existing dependencies. 

Please let me know if I should make any changes 🙏 