### PR TITLE
fix 'undefined is not iterable' when printing json output

### DIFF
--- a/src/print-trace-analysis-json.ts
+++ b/src/print-trace-analysis-json.ts
@@ -111,7 +111,7 @@ async function getHotSpotsWorker(curr: EventSpan, currentFile: string | undefine
         // Sort slow to fast
         const sortedChildren = curr.children.sort((a, b) => (b.end - b.start) - (a.end - a.start));
         for (const child of sortedChildren) {
-            children.push(...await getHotSpotsWorker(child, currentFile, positionMap, relatedTypes, importExpressionThreshold));
+            children.push(...(await getHotSpotsWorker(child, currentFile, positionMap, relatedTypes, importExpressionThreshold) || []));
         }
     }
 


### PR DESCRIPTION
currently running `analyze-trace` with `--json` flag results in:
```
Internal Error: undefined is not iterable (cannot read property Symbol(Symbol.iterator))\nTypeError: undefined is not iterable
```
(`getHotSpotsWorker` can return `undefined` in some cases)