### PR TITLE
fix: update `README.md` to correct `npx` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The short version is to run these commands:
 ```sh
 tsc -p path/to/tsconfig.json --generateTrace traceDir
 npm install --no-save @typescript/analyze-trace
-npx analyze-trace traceDir
+npx @typescript/analyze-trace traceDir
 ```
 
 Each of these commands do the following:
@@ -20,13 +20,13 @@ Each of these commands do the following:
 1. Building your project with `--generateTrace` targeting a specific directory (e.g.`tsc -p path/to/tsconfig.json --generateTrace traceDir`) will create a new `traceDir` directory with paired trace and types files.
    Note that running with `-b`/`--build` mode works as well.
 2. Installing `@typescript/analyze-trace` makes its various commands available in your project.
-3. Running `npx analyze-trace traceDir` outputs a sorted list of compilation hot-spots - places where TypeScript is taking a high amount of time.
+3. Running `npx @typescript/analyze-trace traceDir` outputs a sorted list of compilation hot-spots - places where TypeScript is taking a high amount of time.
 
 The analyzer tries to refer back to files from your project to provide better output, and uses relative paths to do so.
 If your project changed since running `tsc --generateTrace`, or you moved your trace output directory, then the tool's results may be misleading.
 For best results, re-run `--generateTrace` when files and dependencies are updated, and ensure the trace output is always in the same relative location with respect to the input project.
 
-You can run `npx analyze-trace --help` to find out about other options including:
+You can run `npx @typescript/analyze-trace --help` to find out about other options including:
 
 Option                    | Default | Description
 --------------------------|---------|-------------------------------------------------------------------------------


### PR DESCRIPTION
now `npx analyze-trace` returns 404 error. We need `@typescript/` prefix.

```
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/analyze-trace - Not found
npm error 404
npm error 404  'analyze-trace@*' is not in this registry.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
```

