### PR TITLE
Support TS 7.0 concurrent tracing

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@typescript/analyze-trace",
   "author": "Microsoft Corp.",
   "homepage": "https://github.com/microsoft/typescript-analyze-trace#readme",
-  "version": "0.10.1",
+  "version": "0.11.0",
   "license": "MIT",
   "description": "Analyze the output of tsc --generatetrace",
   "keywords": [

--- a/src/analyze-trace-dir.ts
+++ b/src/analyze-trace-dir.ts
@@ -59,6 +59,7 @@ interface SerializableProject {
     tracePath: string;
     typesPath?: string;
     typesPaths?: string[];
+    typeSources?: TypeSource[];
 }
 
 async function main(): Promise<number> {
@@ -235,6 +236,7 @@ function serializeProject(project: Project): SerializableProject {
         tracePath: project.tracePath,
         typesPath: typesPaths?.length === 1 ? typesPaths[0] : undefined,
         typesPaths: typesPaths && typesPaths.length > 1 ? typesPaths : undefined,
+        typeSources: project.typeSources,
     };
 }
 

--- a/src/analyze-trace-dir.ts
+++ b/src/analyze-trace-dir.ts
@@ -10,8 +10,13 @@ import exit = require("exit");
 import plimit = require("p-limit");
 import yargs = require("yargs");
 
-import { TypeSource, typeSourcesEnvVar } from "./analyze-trace-utilities";
-import { commandLineOptions, checkCommandLineOptions, pushCommandLineOptions } from "./analyze-trace-options";
+import { TypeSource } from "./analyze-trace-utilities";
+import { commandLineOptions, checkCommandLineOptions } from "./analyze-trace-options";
+
+// Mirror of the worker's defaults; kept here so the dir analyzer is the single source of truth
+// for what gets handed to each worker invocation.
+const minPercentage = 0.6;
+const importExpressionThreshold = 10;
 
 const argv = yargs(process.argv.slice(2))
     .command("$0 <traceDir>", "Preprocess tracing type dumps", yargs => yargs
@@ -241,21 +246,21 @@ function serializeProject(project: Project): SerializableProject {
 }
 
 async function analyzeProject(project: Project): Promise<ProjectResult> {
-    const args = [ project.tracePath ];
     const typeSources = await getExistingTypeSources(project);
-    pushCommandLineOptions(args, argv);
-    const childEnv = { ...process.env };
-    if (typeSources) {
-        childEnv[typeSourcesEnvVar] = JSON.stringify(typeSources);
-    }
-    else {
-        delete childEnv[typeSourcesEnvVar];
-    }
+    const payload = {
+        tracePath: project.tracePath,
+        typeSources,
+        forceMillis: argv.forceMillis,
+        skipMillis: argv.skipMillis,
+        expandTypes: argv.expandTypes,
+        json: argv.json,
+        minPercentage,
+        importExpressionThreshold,
+    };
 
     return new Promise<ProjectResult>(resolve => {
-        const child = cp.fork(path.join(__dirname, "analyze-trace-file"), args, {
+        const child = cp.fork(path.join(__dirname, "analyze-trace-file"), [JSON.stringify(payload)], {
             stdio: "pipe",
-            env: childEnv,
         });
 
         let stdout = "";

--- a/src/analyze-trace-dir.ts
+++ b/src/analyze-trace-dir.ts
@@ -10,6 +10,7 @@ import exit = require("exit");
 import plimit = require("p-limit");
 import yargs = require("yargs");
 
+import { TypeSource, typeSourcesEnvVar } from "./analyze-trace-utilities";
 import { commandLineOptions, checkCommandLineOptions, pushCommandLineOptions } from "./analyze-trace-options";
 
 const argv = yargs(process.argv.slice(2))
@@ -37,7 +38,12 @@ main()
 interface Project {
     configFilePath?: string;
     tracePath: string;
-    typesPath: string;
+    typeSources?: TypeSource[];
+}
+
+interface LegendProject extends Project {
+    typesPath?: string;
+    checkerId?: number;
 }
 
 interface ProjectResult {
@@ -48,6 +54,13 @@ interface ProjectResult {
     signal: NodeJS.Signals | undefined;
 }
 
+interface SerializableProject {
+    configFilePath?: string;
+    tracePath: string;
+    typesPath?: string;
+    typesPaths?: string[];
+}
+
 async function main(): Promise<number> {
     let projects: undefined | Project[];
 
@@ -55,12 +68,7 @@ async function main(): Promise<number> {
     if (await isFile(legendPath)) {
         try {
             const legendText = await fs.promises.readFile(legendPath, { encoding: "utf-8" });
-            projects = JSON.parse(legendText);
-
-            for (const project of projects!) {
-                project.tracePath = path.resolve(traceDir, path.basename(project.tracePath));
-                project.typesPath = path.resolve(traceDir, path.basename(project.typesPath));
-            }
+            projects = coalesceProjectsFromLegend(JSON.parse(legendText));
         }
         catch (e: any) {
             console.error(`Error reading legend file: ${e.message}`);
@@ -78,7 +86,7 @@ async function main(): Promise<number> {
             if (match) {
                 projects.push({
                     tracePath: path.join(traceDir, name),
-                    typesPath: path.join(traceDir, `types${match[1]}`),
+                    typeSources: [{ typesPath: path.join(traceDir, `types${match[1]}`) }],
                 });
             }
         }
@@ -122,13 +130,14 @@ async function printResultsAsJson(results: readonly ProjectResult[]): Promise<nu
             ? undefined
             : hadErrors.map(result => ({
                 ...result,
+                project: serializeProject(result.project),
                 stdout: undefined,
                 stderr: undefined,
                 exitCode: result.exitCode || undefined,
                 message: result.stderr,
             })),
         results: hadNoErrors.map(result => ({
-            project: result.project,
+            project: serializeProject(result.project),
             highlights: result.highlights,
         })),
     };
@@ -219,15 +228,33 @@ function getProjectDescription(project: Project) {
        : path.basename(project.tracePath);
 }
 
+function serializeProject(project: Project): SerializableProject {
+    const typesPaths = project.typeSources?.map(source => source.typesPath);
+    return {
+        configFilePath: project.configFilePath,
+        tracePath: project.tracePath,
+        typesPath: typesPaths?.length === 1 ? typesPaths[0] : undefined,
+        typesPaths: typesPaths && typesPaths.length > 1 ? typesPaths : undefined,
+    };
+}
+
 async function analyzeProject(project: Project): Promise<ProjectResult> {
     const args = [ project.tracePath ];
-    if (await isFile(project.typesPath)) {
-        args.push(project.typesPath);
-    }
+    const typeSources = await getExistingTypeSources(project);
     pushCommandLineOptions(args, argv);
+    const childEnv = { ...process.env };
+    if (typeSources) {
+        childEnv[typeSourcesEnvVar] = JSON.stringify(typeSources);
+    }
+    else {
+        delete childEnv[typeSourcesEnvVar];
+    }
 
     return new Promise<ProjectResult>(resolve => {
-        const child = cp.fork(path.join(__dirname, "analyze-trace-file"), args, { stdio: "pipe" });
+        const child = cp.fork(path.join(__dirname, "analyze-trace-file"), args, {
+            stdio: "pipe",
+            env: childEnv,
+        });
 
         let stdout = "";
         let stderr = "";
@@ -245,6 +272,53 @@ async function analyzeProject(project: Project): Promise<ProjectResult> {
             });
         });
     });
+}
+
+async function getExistingTypeSources(project: Project): Promise<TypeSource[] | undefined> {
+    if (!project.typeSources) {
+        return undefined;
+    }
+
+    const existing: TypeSource[] = [];
+    for (const source of project.typeSources) {
+        if (await isFile(source.typesPath)) {
+            existing.push(source);
+        }
+    }
+
+    return existing.length ? existing : undefined;
+}
+
+function coalesceProjectsFromLegend(legend: LegendProject[]): Project[] {
+    const projectMap = new Map<string, Project>();
+    for (const legendProject of legend) {
+        const tracePath = path.resolve(traceDir, path.basename(legendProject.tracePath));
+        const typesPath = legendProject.typesPath && path.resolve(traceDir, path.basename(legendProject.typesPath));
+        const typeSource = typesPath
+            ? { typesPath, checkerId: legendProject.checkerId }
+            : undefined;
+        const key = `${legendProject.configFilePath || ""}\n${tracePath}`;
+
+        let project = projectMap.get(key);
+        if (!project) {
+            project = {
+                configFilePath: legendProject.configFilePath,
+                tracePath,
+                typeSources: typeSource ? [typeSource] : undefined,
+            };
+            projectMap.set(key, project);
+            continue;
+        }
+
+        if (typesPath) {
+            project.typeSources ??= [];
+            if (!project.typeSources.some(source => source.typesPath === typesPath && source.checkerId === legendProject.checkerId)) {
+                project.typeSources.push(typeSource!);
+            }
+        }
+    }
+
+    return Array.from(projectMap.values());
 }
 
 function isFile(path: string): Promise<boolean> {

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -24,7 +24,6 @@ const argv = yargs(process.argv.slice(2))
 
 const tracePath = argv.tracePath!;
 const typesPath = argv.typesPath;
-const typeSources = argv.expandTypes ? getTypeSources() : undefined;
 
 const thresholdDuration = argv.forceMillis * 1000; // microseconds
 const minDuration = argv.skipMillis * 1000; // microseconds
@@ -33,12 +32,17 @@ const importExpressionThreshold = 10;
 
 const reportHighlights = argv.json ? reportJson : reportText;
 
-reportHighlights(tracePath, typeSources, thresholdDuration, minDuration, minPercentage, importExpressionThreshold)
+run()
   .then(found => exit(found ? 0 : 1))
   .catch(err => {
     console.error(`Internal Error: ${err.message}\n${err.stack}`)
     exit(2);
 });
+
+async function run(): Promise<boolean> {
+    const typeSources = argv.expandTypes ? getTypeSources() : undefined;
+    return await reportHighlights(tracePath, typeSources, thresholdDuration, minDuration, minPercentage, importExpressionThreshold);
+}
 
 function throwIfNotFile(path: string): string {
     if (!fs.existsSync(path) || !fs.statSync(path)?.isFile()) {
@@ -57,7 +61,14 @@ function getTypeSources(): readonly TypeSource[] | undefined {
 }
 
 function parseTypeSources(json: string): readonly TypeSource[] {
-    const sources = JSON.parse(json);
+    let sources: unknown;
+    try {
+        sources = JSON.parse(json);
+    }
+    catch (e: any) {
+        throw new Error(`${typeSourcesEnvVar} must be valid JSON: ${e.message}`);
+    }
+
     if (!Array.isArray(sources)) {
         throw new Error(`${typeSourcesEnvVar} must be a JSON array`);
     }

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -1,86 +1,51 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
+//
+// Internal worker process spawned by analyze-trace-dir. Not a public CLI.
+// Receives a single JSON payload describing what to analyze and prints the
+// results to stdout (text or JSON, per the payload).
 
-import fs = require("fs");
 import exit = require("exit");
-import yargs = require("yargs");
 
-import { commandLineOptions, checkCommandLineOptions } from "./analyze-trace-options";
 import { reportHighlights as reportText } from "./print-trace-analysis-text";
 import { reportHighlights as reportJson } from "./print-trace-analysis-json";
-import { TypeSource, typeSourcesEnvVar } from "./analyze-trace-utilities";
+import { TypeSource } from "./analyze-trace-utilities";
 
-const argv = yargs(process.argv.slice(2))
-    .command("$0 <tracePath> [typesPath]", "Preprocess tracing type dumps", yargs => yargs
-        .positional("tracePath", { type: "string", desc: "Trace file to read", coerce: throwIfNotFile })
-        .positional("typesPath", { type: "string", desc: "Corresponding types file", coerce: throwIfNotFile })
-        .options(commandLineOptions)
-        .check(checkCommandLineOptions)
-        .help("h").alias("h", "help")
-        .epilog("Exits with code 0 if highlights were found, 1 if no highlights were found, and 2 if an error occurred")
-        .strict())
-    .argv;
-
-
-const tracePath = argv.tracePath!;
-const typesPath = argv.typesPath;
-
-const thresholdDuration = argv.forceMillis * 1000; // microseconds
-const minDuration = argv.skipMillis * 1000; // microseconds
-const minPercentage = 0.6;
-const importExpressionThreshold = 10;
-
-const reportHighlights = argv.json ? reportJson : reportText;
+interface WorkerPayload {
+    tracePath: string;
+    typeSources?: TypeSource[];
+    forceMillis: number;
+    skipMillis: number;
+    expandTypes: boolean;
+    json: boolean;
+    importExpressionThreshold: number;
+    minPercentage: number;
+}
 
 run()
-  .then(found => exit(found ? 0 : 1))
-  .catch(err => {
-    console.error(`Internal Error: ${err.message}\n${err.stack}`)
-    exit(2);
-});
+    .then(found => exit(found ? 0 : 1))
+    .catch(err => {
+        console.error(`Internal Error: ${err.message}\n${err.stack}`);
+        exit(2);
+    });
 
 async function run(): Promise<boolean> {
-    const typeSources = argv.expandTypes ? getTypeSources() : undefined;
-    return await reportHighlights(tracePath, typeSources, thresholdDuration, minDuration, minPercentage, importExpressionThreshold);
+    const payload = parsePayload(process.argv[2]);
+    const reportHighlights = payload.json ? reportJson : reportText;
+    const typeSources = payload.expandTypes ? payload.typeSources : undefined;
+    return await reportHighlights(
+        payload.tracePath,
+        typeSources,
+        payload.forceMillis * 1000,
+        payload.skipMillis * 1000,
+        payload.minPercentage,
+        payload.importExpressionThreshold,
+    );
 }
 
-function throwIfNotFile(path: string): string {
-    if (!fs.existsSync(path) || !fs.statSync(path)?.isFile()) {
-        throw new Error(`${path} is not a file`);
+function parsePayload(raw: string | undefined): WorkerPayload {
+    if (!raw) {
+        throw new Error("analyze-trace-file: missing JSON payload argument");
     }
-    return path;
-}
-
-function getTypeSources(): readonly TypeSource[] | undefined {
-    const typeSourcesJson = process.env[typeSourcesEnvVar];
-    if (typeSourcesJson) {
-        return parseTypeSources(typeSourcesJson);
-    }
-
-    return typesPath ? [{ typesPath }] : undefined;
-}
-
-function parseTypeSources(json: string): readonly TypeSource[] {
-    let sources: unknown;
-    try {
-        sources = JSON.parse(json);
-    }
-    catch (e: any) {
-        throw new Error(`${typeSourcesEnvVar} must be valid JSON: ${e.message}`);
-    }
-
-    if (!Array.isArray(sources)) {
-        throw new Error(`${typeSourcesEnvVar} must be a JSON array`);
-    }
-
-    return sources.map((source: any) => {
-        if (!source || typeof source.typesPath !== "string") {
-            throw new Error(`${typeSourcesEnvVar} entries must include a typesPath`);
-        }
-        throwIfNotFile(source.typesPath);
-        return {
-            typesPath: source.typesPath,
-            checkerId: typeof source.checkerId === "number" ? source.checkerId : undefined,
-        };
-    });
+    return JSON.parse(raw);
 }

--- a/src/analyze-trace-file.ts
+++ b/src/analyze-trace-file.ts
@@ -8,6 +8,7 @@ import yargs = require("yargs");
 import { commandLineOptions, checkCommandLineOptions } from "./analyze-trace-options";
 import { reportHighlights as reportText } from "./print-trace-analysis-text";
 import { reportHighlights as reportJson } from "./print-trace-analysis-json";
+import { TypeSource, typeSourcesEnvVar } from "./analyze-trace-utilities";
 
 const argv = yargs(process.argv.slice(2))
     .command("$0 <tracePath> [typesPath]", "Preprocess tracing type dumps", yargs => yargs
@@ -23,6 +24,7 @@ const argv = yargs(process.argv.slice(2))
 
 const tracePath = argv.tracePath!;
 const typesPath = argv.typesPath;
+const typeSources = argv.expandTypes ? getTypeSources() : undefined;
 
 const thresholdDuration = argv.forceMillis * 1000; // microseconds
 const minDuration = argv.skipMillis * 1000; // microseconds
@@ -31,7 +33,7 @@ const importExpressionThreshold = 10;
 
 const reportHighlights = argv.json ? reportJson : reportText;
 
-reportHighlights(tracePath, argv.expandTypes ? typesPath : undefined, thresholdDuration, minDuration, minPercentage, importExpressionThreshold)
+reportHighlights(tracePath, typeSources, thresholdDuration, minDuration, minPercentage, importExpressionThreshold)
   .then(found => exit(found ? 0 : 1))
   .catch(err => {
     console.error(`Internal Error: ${err.message}\n${err.stack}`)
@@ -43,4 +45,31 @@ function throwIfNotFile(path: string): string {
         throw new Error(`${path} is not a file`);
     }
     return path;
+}
+
+function getTypeSources(): readonly TypeSource[] | undefined {
+    const typeSourcesJson = process.env[typeSourcesEnvVar];
+    if (typeSourcesJson) {
+        return parseTypeSources(typeSourcesJson);
+    }
+
+    return typesPath ? [{ typesPath }] : undefined;
+}
+
+function parseTypeSources(json: string): readonly TypeSource[] {
+    const sources = JSON.parse(json);
+    if (!Array.isArray(sources)) {
+        throw new Error(`${typeSourcesEnvVar} must be a JSON array`);
+    }
+
+    return sources.map((source: any) => {
+        if (!source || typeof source.typesPath !== "string") {
+            throw new Error(`${typeSourcesEnvVar} entries must include a typesPath`);
+        }
+        throwIfNotFile(source.typesPath);
+        return {
+            typesPath: source.typesPath,
+            checkerId: typeof source.checkerId === "number" ? source.checkerId : undefined,
+        };
+    });
 }

--- a/src/analyze-trace-options.ts
+++ b/src/analyze-trace-options.ts
@@ -47,13 +47,3 @@ export function checkCommandLineOptions(argv: Argv): true {
     }
     return true;
 }
-
-export function pushCommandLineOptions(array: string[], argv: Argv): void {
-    array.push(
-        "--force-millis", `${argv.forceMillis}`,
-        "--skip-millis", `${argv.skipMillis}`,
-        argv.expandTypes ? "--expand-types" : "--no-expand-types",
-        argv.color ? "--color" : "--no-color",
-        argv.json ? "--json" : "--no-json",
-    );
-}

--- a/src/analyze-trace-utilities.ts
+++ b/src/analyze-trace-utilities.ts
@@ -6,7 +6,7 @@ import path = require("path");
 import countImportExpressions = require("./count-import-expressions");
 import normalizePositions = require("./normalize-positions");
 import simplify = require("./simplify-type");
-import { Event, EventSpan, ParseResult } from "./parse-trace-file";
+import { Event, EventSpan, ParseResult, getEventStackKey } from "./parse-trace-file";
 
 import jsonstream = require("jsonstream-next");
 
@@ -47,7 +47,7 @@ export function buildHotPathsTree(parseResult: ParseResult, thresholdDuration: n
 
     function getStack(span: EventSpan): EventSpan[] {
         const event = span.event;
-        const key = `${event?.pid ?? 1}:${event?.tid ?? 1}`;
+        const key = event ? getEventStackKey(event) : "1:1";
         let stack = stacks.get(key);
         if (!stack) {
             stack = [ root ];

--- a/src/analyze-trace-utilities.ts
+++ b/src/analyze-trace-utilities.ts
@@ -144,8 +144,6 @@ export interface TypeSource {
 
 export type TypeSources = readonly TypeSource[];
 
-export const typeSourcesEnvVar = "TYPESCRIPT_ANALYZE_TRACE_TYPE_SOURCES";
-
 export async function getPackageVersion(packagePath: string): Promise<string | undefined> {
     try {
         const jsonPath = path.join(packagePath, "package.json");

--- a/src/analyze-trace-utilities.ts
+++ b/src/analyze-trace-utilities.ts
@@ -6,7 +6,7 @@ import path = require("path");
 import countImportExpressions = require("./count-import-expressions");
 import normalizePositions = require("./normalize-positions");
 import simplify = require("./simplify-type");
-import { EventSpan, ParseResult } from "./parse-trace-file";
+import { Event, EventSpan, ParseResult } from "./parse-trace-file";
 
 import jsonstream = require("jsonstream-next");
 
@@ -18,22 +18,23 @@ export function buildHotPathsTree(parseResult: ParseResult, thresholdDuration: n
         spans.push({ event, start: +event.ts, end: maxTime, children: [] });
     }
 
-    spans.sort((a, b) => a.start - b.start);
+    spans.sort((a, b) => a.start - b.start || b.end - a.end);
 
     const root: EventSpan = { start: minTime, end: maxTime, children: [] };
-    const stack = [ root ];
+    const stacks = new Map<string, EventSpan[]>();
 
     for (const span of spans) {
+        const stack = getStack(span);
         let i = stack.length - 1;
         for (; i > 0; i--) { // No need to check root at stack[0]
             const curr = stack[i];
-            if (curr.end > span.start) {
-                // Pop down to parent
-                stack.length = i + 1;
+            if (contains(curr, span)) {
                 break;
             }
         }
 
+        // Pop down to parent, or to the root if this is a sibling of the whole lane.
+        stack.length = i + 1;
         const parent = stack[i];
         const duration = span.end - span.start;
         if (duration >= thresholdDuration || duration >= minPercentage * (parent.end - parent.start)) {
@@ -43,19 +44,36 @@ export function buildHotPathsTree(parseResult: ParseResult, thresholdDuration: n
     }
 
     return root;
+
+    function getStack(span: EventSpan): EventSpan[] {
+        const event = span.event;
+        const key = `${event?.pid ?? 1}:${event?.tid ?? 1}`;
+        let stack = stacks.get(key);
+        if (!stack) {
+            stack = [ root ];
+            stacks.set(key, stack);
+        }
+        return stack;
+    }
+
+    function contains(parent: EventSpan, child: EventSpan): boolean {
+        return parent.start <= child.start && child.end <= parent.end;
+    }
 }
 
 type LineChar = normalizePositions.LineChar;
 export type PositionMap = Map<string, Map<string, LineChar>>; // Path to position (offset or LineChar) to LineChar
 
-export async function getNormalizedPositions(root: EventSpan, relatedTypes: Map<number, object> | undefined): Promise<PositionMap> {
+export async function getNormalizedPositions(root: EventSpan, relatedTypes: readonly Map<number, object>[] | undefined): Promise<PositionMap> {
     const positionMap = new Map<string, (number | LineChar)[]>();
     recordPositions(root, /*currentFile*/ undefined);
     if (relatedTypes) {
-        for (const type of relatedTypes.values()) {
-            const location: any = (type as any).location;
-            if (location) {
-                recordPosition(location.path, [ location.line, location.char ]);
+        for (const relatedTypesForSource of relatedTypes) {
+            for (const type of relatedTypesForSource.values()) {
+                const location: any = (type as any).location;
+                if (location) {
+                    recordPosition(location.path, [ location.line, location.char ]);
+                }
             }
         }
     }
@@ -86,7 +104,7 @@ export async function getNormalizedPositions(root: EventSpan, relatedTypes: Map<
 
     function recordPositions(span: EventSpan, currentFile: string | undefined): void {
         if (span.event?.name === "checkSourceFile") {
-            currentFile = span.event!.args!.path;
+            currentFile = span.event.args?.path ?? currentFile;
         }
         else if (span.event?.cat === "check") {
             const args = span.event.args;
@@ -119,6 +137,15 @@ export function getLineCharMapKey(line: number, char: number) {
     return `${line},${char}`;
 }
 
+export interface TypeSource {
+    typesPath: string;
+    checkerId?: number;
+}
+
+export type TypeSources = readonly TypeSource[];
+
+export const typeSourcesEnvVar = "TYPESCRIPT_ANALYZE_TRACE_TYPE_SOURCES";
+
 export async function getPackageVersion(packagePath: string): Promise<string | undefined> {
     try {
         const jsonPath = path.join(packagePath, "package.json");
@@ -150,22 +177,23 @@ export function unmangleCamelCase(name: string) {
     return result;
 }
 
-let typesCache: undefined | readonly any[];
+const typesCache = new Map<string, Promise<readonly any[]>>();
 export async function getTypes(typesPath: string): Promise<readonly any[]> {
-    if (!typesCache) {
-        return new Promise((resolve, _reject) => {
-            typesCache = [];
+    let typesPromise = typesCache.get(typesPath);
+    if (!typesPromise) {
+        typesPromise = new Promise((resolve, _reject) => {
+            const types: any[] = [];
 
             const readStream = fs.createReadStream(typesPath, { encoding: "utf-8" });
             readStream.on("end", () => {
-                resolve(typesCache!);
+                resolve(types);
             });
             readStream.on("error", onError);
 
             // expects types file to be {object[]}
             const parser = jsonstream.parse("*");
             parser.on("data", (data: object) => {
-                (typesCache as any[]).push(data);
+                types.push(data);
             });
             parser.on("error", onError);
 
@@ -173,12 +201,13 @@ export async function getTypes(typesPath: string): Promise<readonly any[]> {
 
             function onError(e: Error) {
                 console.error(`Error reading types file: ${e.message}`);
-                resolve(typesCache!);
+                resolve(types);
             }
         });
+        typesCache.set(typesPath, typesPromise);
     }
 
-    return typesCache;
+    return typesPromise;
 }
 
 export interface EmittedImport {
@@ -196,8 +225,10 @@ export async function getEmittedImports(dtsPath: string, importExpressionThresho
     return sorted;
 }
 
-export async function getRelatedTypes(root: EventSpan, typesPath: string, leafOnly: boolean): Promise<Map<number, object>> {
-    const relatedTypes = new Map<number, object>();
+export type RelatedTypes = Map<string, Map<number, object>>;
+
+export async function getRelatedTypes(root: EventSpan, typeSources: TypeSources, leafOnly: boolean): Promise<RelatedTypes> {
+    const relatedTypes = new Map<string, Map<number, object>>();
 
     const stack: EventSpan[] = [];
     stack.push(root);
@@ -206,16 +237,38 @@ export async function getRelatedTypes(root: EventSpan, typesPath: string, leafOn
         const curr = stack.pop()!;
         if (!leafOnly || curr.children.length === 0) {
             if (curr.event?.name === "structuredTypeRelatedTo") {
-                const types = await getTypes(typesPath);
+                const args = curr.event.args;
+                if (!args) {
+                    stack.push(...curr.children);
+                    continue;
+                }
+                const typeSource = getTypeSourceForEvent(typeSources, curr.event);
+                if (!typeSource) {
+                    stack.push(...curr.children);
+                    continue;
+                }
+                const types = await getTypes(typeSource.typesPath);
                 if (types.length) {
-                    addRelatedTypes(types, curr.event.args!.sourceId, relatedTypes);
-                    addRelatedTypes(types, curr.event.args!.targetId, relatedTypes);
+                    const relatedTypesForSource = getRelatedTypesForSource(relatedTypes, typeSource);
+                    addRelatedTypes(types, args.sourceId, relatedTypesForSource);
+                    addRelatedTypes(types, args.targetId, relatedTypesForSource);
                 }
             }
             else if (curr.event?.name === "getVariancesWorker") {
-                const types = await getTypes(typesPath);
+                const args = curr.event.args;
+                if (!args) {
+                    stack.push(...curr.children);
+                    continue;
+                }
+                const typeSource = getTypeSourceForEvent(typeSources, curr.event);
+                if (!typeSource) {
+                    stack.push(...curr.children);
+                    continue;
+                }
+                const types = await getTypes(typeSource.typesPath);
                 if (types.length) {
-                    addRelatedTypes(types, curr.event.args!.id, relatedTypes);
+                    const relatedTypesForSource = getRelatedTypesForSource(relatedTypes, typeSource);
+                    addRelatedTypes(types, args.id, relatedTypesForSource);
                 }
             }
         }
@@ -224,6 +277,46 @@ export async function getRelatedTypes(root: EventSpan, typesPath: string, leafOn
     }
 
     return relatedTypes;
+}
+
+export function getRelatedTypesForEvent(relatedTypes: RelatedTypes | undefined, typeSources: TypeSources | undefined, event: Event): Map<number, object> | undefined {
+    if (!relatedTypes || !typeSources) {
+        return undefined;
+    }
+
+    const typeSource = getTypeSourceForEvent(typeSources, event);
+    return typeSource && relatedTypes.get(getTypeSourceKey(typeSource));
+}
+
+export function getAllRelatedTypes(relatedTypes: RelatedTypes | undefined): Map<number, object>[] | undefined {
+    return relatedTypes && Array.from(relatedTypes.values());
+}
+
+function getRelatedTypesForSource(relatedTypes: RelatedTypes, typeSource: TypeSource): Map<number, object> {
+    const key = getTypeSourceKey(typeSource);
+    let relatedTypesForSource = relatedTypes.get(key);
+    if (!relatedTypesForSource) {
+        relatedTypesForSource = new Map<number, object>();
+        relatedTypes.set(key, relatedTypesForSource);
+    }
+    return relatedTypesForSource;
+}
+
+function getTypeSourceForEvent(typeSources: TypeSources, event: Event): TypeSource | undefined {
+    if (typeSources.length === 1) {
+        return typeSources[0];
+    }
+
+    const checkerId = event.args?.checkerId;
+    if (checkerId === undefined) {
+        return undefined;
+    }
+
+    return typeSources.find(typeSource => typeSource.checkerId === checkerId);
+}
+
+function getTypeSourceKey(typeSource: TypeSource): string {
+    return typeSource.checkerId === undefined ? typeSource.typesPath : `${typeSource.checkerId}`;
 }
 
 function addRelatedTypes(types: readonly object[], id: number, relatedTypes: Map<number, object>): void {

--- a/src/analyze-trace-utilities.ts
+++ b/src/analyze-trace-utilities.ts
@@ -316,7 +316,9 @@ function getTypeSourceForEvent(typeSources: TypeSources, event: Event): TypeSour
 }
 
 function getTypeSourceKey(typeSource: TypeSource): string {
-    return typeSource.checkerId === undefined ? typeSource.typesPath : `${typeSource.checkerId}`;
+    return typeSource.checkerId === undefined
+        ? `path:${typeSource.typesPath}`
+        : `checkerId:${typeSource.checkerId}:path:${typeSource.typesPath}`;
 }
 
 function addRelatedTypes(types: readonly object[], id: number, relatedTypes: Map<number, object>): void {

--- a/src/parse-trace-file.ts
+++ b/src/parse-trace-file.ts
@@ -9,8 +9,10 @@ const packageNameRegex = /\/node_modules\/((?:[^@][^/]+)|(?:@[^/]+\/[^/]+))/g;
 
 export interface Event {
     ph: string;
-    ts: string;
-    dur?: string;
+    ts: string | number;
+    dur?: string | number;
+    pid?: string | number;
+    tid?: string | number;
     name: string;
     cat: string;
     args?: any;
@@ -28,6 +30,7 @@ export interface ParseResult {
     maxTime: number;
     spans: EventSpan[];
     unclosedStack: Event[];
+    unmatchedEndEvents: Event[];
     nodeModulePaths: Map<string, string[]>;
 }
 
@@ -37,7 +40,8 @@ export function parse(tracePath: string, minDuration: number): Promise<ParseResu
 
         let minTime = Infinity;
         let maxTime = 0;
-        const unclosedStack: Event[] = []; // Sorted in increasing order of start time (even when below timestamp resolution)
+        const stacks = new Map<string, Event[]>();
+        const unmatchedEndEvents: Event[] = [];
         const spans: EventSpan[] = []; // Sorted in increasing order of end time, then increasing order of start time (even when below timestamp resolution)
         const nodeModulePaths = new Map<string, string[]>();
         p.onValue = function (value: any) {
@@ -54,14 +58,20 @@ export function parse(tracePath: string, minDuration: number): Promise<ParseResu
             const event = value as Event;
 
             if (event.ph === "B") {
-                unclosedStack.push(event);
+                getStack(stacks, getEventStackKey(event)).push(event);
                 return;
             }
 
             let span: EventSpan;
             if (event.ph === "E") {
-                const beginEvent = unclosedStack.pop()!;
-                span = { event: beginEvent, start: +beginEvent.ts, end: +event.ts, children: [] };
+                const stack = getStack(stacks, getEventStackKey(event));
+                const beginEvent = stack[stack.length - 1];
+                if (!beginEvent || !isMatchingBegin(beginEvent, event)) {
+                    unmatchedEndEvents.push(event);
+                    return;
+                }
+                stack.pop();
+                span = { event: mergeBeginAndEnd(beginEvent, event), start: +beginEvent.ts, end: +event.ts, children: [] };
             }
             else if (event.ph === "X") {
                 const start = +event.ts;
@@ -79,6 +89,7 @@ export function parse(tracePath: string, minDuration: number): Promise<ParseResu
             if (span.event!.name === "findSourceFile") {
                 const path = span.event!.args?.fileName;
                 if (path) {
+                    packageNameRegex.lastIndex = 0;
                     while (true) {
                         const m = packageNameRegex.exec(path);
                         if (!m) break;
@@ -105,13 +116,49 @@ export function parse(tracePath: string, minDuration: number): Promise<ParseResu
         const readStream = fs.createReadStream(tracePath);
         readStream.on("data", chunk => p.write(chunk));
         readStream.on("end", () => {
+            const unclosedStack: Event[] = [];
+            for (const stack of stacks.values()) {
+                unclosedStack.push(...stack);
+            }
             resolve({
                 minTime,
                 maxTime,
                 spans,
                 unclosedStack,
+                unmatchedEndEvents,
                 nodeModulePaths,
             });
         });
     });
+}
+
+function getStack(stacks: Map<string, Event[]>, key: string): Event[] {
+    let stack = stacks.get(key);
+    if (!stack) {
+        stack = [];
+        stacks.set(key, stack);
+    }
+    return stack;
+}
+
+function getEventStackKey(event: Event): string {
+    return `${event.pid ?? 1}:${event.tid ?? 1}`;
+}
+
+function isMatchingBegin(beginEvent: Event, endEvent: Event): boolean {
+    return beginEvent.name === endEvent.name && beginEvent.cat === endEvent.cat;
+}
+
+function mergeBeginAndEnd(beginEvent: Event, endEvent: Event): Event {
+    if (!beginEvent.args && !endEvent.args) {
+        return beginEvent;
+    }
+
+    return {
+        ...beginEvent,
+        args: {
+            ...beginEvent.args,
+            ...endEvent.args,
+        },
+    };
 }

--- a/src/parse-trace-file.ts
+++ b/src/parse-trace-file.ts
@@ -141,7 +141,7 @@ function getStack(stacks: Map<string, Event[]>, key: string): Event[] {
     return stack;
 }
 
-function getEventStackKey(event: Event): string {
+export function getEventStackKey(event: Event): string {
     return `${event.pid ?? 1}:${event.tid ?? 1}`;
 }
 

--- a/src/print-trace-analysis-json.ts
+++ b/src/print-trace-analysis-json.ts
@@ -1,16 +1,15 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { assert } from "console";
 import fs = require("fs");
 import path = require("path");
 
 import { EventSpan, parse } from "./parse-trace-file";
-import { buildHotPathsTree, EmittedImport, getEmittedImports, getLineCharMapKey, getNormalizedPositions, getPackageVersion, getRelatedTypes, getTypes, PositionMap, unmangleCamelCase } from "./analyze-trace-utilities";
+import { buildHotPathsTree, EmittedImport, getAllRelatedTypes, getEmittedImports, getLineCharMapKey, getNormalizedPositions, getPackageVersion, getRelatedTypes, getRelatedTypesForEvent, PositionMap, RelatedTypes, TypeSources, unmangleCamelCase } from "./analyze-trace-utilities";
 
 export async function reportHighlights(
     tracePath: string,
-    typesPath: string | undefined,
+    typeSources: TypeSources | undefined,
     thresholdDuration: number,
     minDuration: number,
     minPercentage: number,
@@ -25,8 +24,9 @@ export async function reportHighlights(
     const unclosedEvents = parseResult.unclosedStack;
     unclosedEvents.reverse();
     result["unterminatedEvents"] = undefinedIfEmpty(unclosedEvents);
+    result["unmatchedEndEvents"] = undefinedIfEmpty(parseResult.unmatchedEndEvents);
 
-    const hotSpots = await getHotSpots(root, importExpressionThreshold, typesPath);
+    const hotSpots = await getHotSpots(root, importExpressionThreshold, typeSources);
     result["hotSpots"] = undefinedIfEmpty(hotSpots);
 
     const duplicatePackages = await getDuplicateNodeModules(parseResult.nodeModulePaths);
@@ -87,21 +87,17 @@ interface HotType {
     children: HotType[];
 }
 
-async function getHotSpots(root: EventSpan, importExpressionThreshold: number, typesPath: string | undefined): Promise<HotFrame[]> {
-    const relatedTypes = typesPath ? await getRelatedTypes(root, typesPath, /*leafOnly*/ false) : undefined;
-    const positionMap = await getNormalizedPositions(root, relatedTypes);
-    const types = typesPath ? await getTypes(typesPath) : undefined;
-    return await getHotSpotsWorker(root, /*currentFile*/ undefined, positionMap, relatedTypes, importExpressionThreshold);
+async function getHotSpots(root: EventSpan, importExpressionThreshold: number, typeSources: TypeSources | undefined): Promise<HotFrame[]> {
+    const relatedTypes = typeSources ? await getRelatedTypes(root, typeSources, /*leafOnly*/ false) : undefined;
+    const positionMap = await getNormalizedPositions(root, getAllRelatedTypes(relatedTypes));
+    return await getHotSpotsWorker(root, /*currentFile*/ undefined, positionMap, relatedTypes, typeSources, importExpressionThreshold);
 }
 
-async function getHotSpotsWorker(curr: EventSpan, currentFile: string | undefined, positionMap: PositionMap, relatedTypes: Map<number, object> | undefined, importExpressionThreshold: number): Promise<HotFrame[]> {
+async function getHotSpotsWorker(curr: EventSpan, currentFile: string | undefined, positionMap: PositionMap, relatedTypes: RelatedTypes | undefined, typeSources: TypeSources | undefined, importExpressionThreshold: number): Promise<HotFrame[]> {
     if (curr.event?.cat === "check") {
-        const path = curr.event.args!.path;
-        if (path) {
-            currentFile = path;
-        }
-        else {
-            assert(curr.event?.name !== "checkSourceFile", "checkSourceFile should have a path");
+        const currentEventPath = curr.event.args?.path;
+        if (currentEventPath) {
+            currentFile = currentEventPath;
         }
     }
 
@@ -111,7 +107,7 @@ async function getHotSpotsWorker(curr: EventSpan, currentFile: string | undefine
         // Sort slow to fast
         const sortedChildren = curr.children.sort((a, b) => (b.end - b.start) - (a.end - a.start));
         for (const child of sortedChildren) {
-            children.push(...await getHotSpotsWorker(child, currentFile, positionMap, relatedTypes, importExpressionThreshold));
+            children.push(...await getHotSpotsWorker(child, currentFile, positionMap, relatedTypes, typeSources, importExpressionThreshold));
         }
     }
 
@@ -130,7 +126,7 @@ async function getHotSpotsWorker(curr: EventSpan, currentFile: string | undefine
             // case "findSourceFile":
             //     TODO (https://github.com/microsoft/typescript-analyze-trace/issues/2)
             case "emitDeclarationFileOrBundle":
-                const dtsPath = event.args.declarationFilePath;
+                const dtsPath = event.args?.declarationFilePath;
                 if (!dtsPath || !fs.existsSync(dtsPath)) {
                     return undefined;
                 }
@@ -151,29 +147,42 @@ async function getHotSpotsWorker(curr: EventSpan, currentFile: string | undefine
                     return undefined;
                 }
             case "checkSourceFile":
+                if (!currentFile) {
+                    return undefined;
+                }
                 return {
                     description: `Check file ${formatPath(currentFile!)}`,
                     timeMs,
                     path: formatPath(currentFile!),
                     children,
                 };
-            case "structuredTypeRelatedTo":
-                const args = event.args!;
+            case "structuredTypeRelatedTo": {
+                const args = event.args;
+                if (!args) {
+                    return undefined;
+                }
+                const eventRelatedTypes = getRelatedTypesForEvent(relatedTypes, typeSources, event);
                 return {
                     description: `Compare types ${args.sourceId} and ${args.targetId}`,
                     timeMs,
                     children,
-                    types: relatedTypes ? [ getHotType(args.sourceId), getHotType(args.targetId) ] : undefined,
+                    types: eventRelatedTypes ? [ getHotType(args.sourceId, eventRelatedTypes), getHotType(args.targetId, eventRelatedTypes) ] : undefined,
                 };
-            case "getVariancesWorker":
+            }
+            case "getVariancesWorker": {
+                if (!event.args) {
+                    return undefined;
+                }
+                const eventRelatedTypes = getRelatedTypesForEvent(relatedTypes, typeSources, event);
                 return {
                     description: `Determine variance of type ${event.args!.id}`,
                     timeMs,
                     children,
-                    types: relatedTypes ? [ getHotType(event.args!.id) ] : undefined,
+                    types: eventRelatedTypes ? [ getHotType(event.args!.id, eventRelatedTypes) ] : undefined,
                 };
+            }
             default:
-                if (event.cat === "check" && event.args && event.args.pos && event.args.end) {
+                if (event.cat === "check" && event.args && event.args.pos && event.args.end && currentFile) {
                     const frame: HotFrame = {
                         description: unmangleCamelCase(event.name),
                         timeMs,
@@ -201,12 +210,12 @@ async function getHotSpotsWorker(curr: EventSpan, currentFile: string | undefine
         }
     }
 
-    function getHotType(id: number): HotType {
+    function getHotType(id: number, eventRelatedTypes: Map<number, object>): HotType {
         return worker(id, [])!;
 
         function worker(id: any, ancestorIds: any[]): HotType | undefined {
             if (typeof id !== "number") return;
-            const type: any = relatedTypes!.get(id);
+            const type: any = eventRelatedTypes.get(id);
             if (!type) return undefined;
 
             if (type.location) {

--- a/src/print-trace-analysis-text.ts
+++ b/src/print-trace-analysis-text.ts
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-import { assert } from "console";
 import chalk = require("chalk");
 import treeify = require("treeify");
 import fs = require("fs");
@@ -9,11 +8,11 @@ import path = require("path");
 
 import getTypeTree = require("./get-type-tree");
 import { EventSpan, parse } from "./parse-trace-file";
-import { buildHotPathsTree, getEmittedImports, getLineCharMapKey, getNormalizedPositions, getPackageVersion, getRelatedTypes, getTypes, PositionMap, unmangleCamelCase } from "./analyze-trace-utilities";
+import { buildHotPathsTree, getAllRelatedTypes, getEmittedImports, getLineCharMapKey, getNormalizedPositions, getPackageVersion, getRelatedTypes, getRelatedTypesForEvent, PositionMap, RelatedTypes, TypeSources, unmangleCamelCase } from "./analyze-trace-utilities";
 
 export async function reportHighlights(
     tracePath: string,
-    typesPath: string | undefined,
+    typeSources: TypeSources | undefined,
     thresholdDuration: number,
     minDuration: number,
     minPercentage: number,
@@ -35,7 +34,18 @@ export async function reportHighlights(
         console.log();
     }
 
-    const sawHotspots = await printHotStacks(root, importExpressionThreshold, typesPath);
+    const unmatchedEndEvents = parseResult.unmatchedEndEvents;
+    if (unmatchedEndEvents.length) {
+        console.log("Trace contains unmatched end events");
+
+        for (const event of unmatchedEndEvents) {
+            console.log(`< ${event.name}: ${JSON.stringify(event.args)}`);
+        }
+
+        console.log();
+    }
+
+    const sawHotspots = await printHotStacks(root, importExpressionThreshold, typeSources);
     console.log();
     const sawDuplicates = await printDuplicateNodeModules(parseResult.nodeModulePaths);
 
@@ -68,11 +78,11 @@ async function printDuplicateNodeModules(nodeModulePaths: Map<string, string[]>)
     return sawDuplicate;
 }
 
-async function printHotStacks(root: EventSpan, importExpressionThreshold: number, typesPath: string | undefined): Promise<boolean> {
-    const relatedTypes = typesPath ? await getRelatedTypes(root, typesPath, /*leafOnly*/ true) : undefined;
+async function printHotStacks(root: EventSpan, importExpressionThreshold: number, typeSources: TypeSources | undefined): Promise<boolean> {
+    const relatedTypes = typeSources ? await getRelatedTypes(root, typeSources, /*leafOnly*/ true) : undefined;
 
-    const positionMap = await getNormalizedPositions(root, relatedTypes);
-    const tree = await makePrintableTree(root, /*currentFile*/ undefined, positionMap, relatedTypes, importExpressionThreshold);
+    const positionMap = await getNormalizedPositions(root, getAllRelatedTypes(relatedTypes));
+    const tree = await makePrintableTree(root, /*currentFile*/ undefined, positionMap, relatedTypes, typeSources, importExpressionThreshold);
 
     const sawHotspots = Object.entries(tree).length > 0;
     if (sawHotspots) {
@@ -85,18 +95,15 @@ async function printHotStacks(root: EventSpan, importExpressionThreshold: number
     return sawHotspots;
 }
 
-async function makePrintableTree(curr: EventSpan, currentFile: string | undefined, positionMap: PositionMap, relatedTypes: Map<number, object> | undefined, importExpressionThreshold: number): Promise<{}> {
+async function makePrintableTree(curr: EventSpan, currentFile: string | undefined, positionMap: PositionMap, relatedTypes: RelatedTypes | undefined, typeSources: TypeSources | undefined, importExpressionThreshold: number): Promise<{}> {
     let childTree = {};
 
     let showCurrentFile = false;
     if (curr.event?.cat === "check") {
-        const path = curr.event.args!.path;
-        if (path) {
-            showCurrentFile = path !== currentFile;
-            currentFile = path;
-        }
-        else {
-            assert(curr.event?.name !== "checkSourceFile", "checkSourceFile should have a path");
+        const currentEventPath = curr.event.args?.path;
+        if (currentEventPath) {
+            showCurrentFile = currentEventPath !== currentFile;
+            currentFile = currentEventPath;
         }
     }
 
@@ -104,7 +111,7 @@ async function makePrintableTree(curr: EventSpan, currentFile: string | undefine
         // Sort slow to fast
         const sortedChildren = curr.children.sort((a, b) => (b.end - b.start) - (a.end - a.start));
         for (const child of sortedChildren) {
-            Object.assign(childTree, await makePrintableTree(child, currentFile, positionMap, relatedTypes, importExpressionThreshold));
+            Object.assign(childTree, await makePrintableTree(child, currentFile, positionMap, relatedTypes, typeSources, importExpressionThreshold));
         }
     }
 
@@ -126,7 +133,7 @@ async function makePrintableTree(curr: EventSpan, currentFile: string | undefine
             // case "findSourceFile":
             //     return `Load file ${event.args!.fileName}`;
             case "emitDeclarationFileOrBundle":
-                const dtsPath = event.args.declarationFilePath;
+                const dtsPath = event.args?.declarationFilePath;
                 if (!dtsPath || !fs.existsSync(dtsPath)) {
                     return undefined;
                 }
@@ -145,27 +152,40 @@ async function makePrintableTree(curr: EventSpan, currentFile: string | undefine
                     return undefined;
                 }
             case "checkSourceFile":
+                if (!currentFile) {
+                    return undefined;
+                }
                 return `Check file ${formatPath(currentFile!)}`;
-            case "structuredTypeRelatedTo":
-                const args = event.args!;
-                if (relatedTypes && curr.children.length === 0) {
+            case "structuredTypeRelatedTo": {
+                const args = event.args;
+                if (!args) {
+                    return undefined;
+                }
+                const eventRelatedTypes = getRelatedTypesForEvent(relatedTypes, typeSources, event);
+                if (eventRelatedTypes && curr.children.length === 0) {
                     const typeTree = {
-                        ...getTypeTree(args.sourceId, relatedTypes),
-                        ...getTypeTree(args.targetId, relatedTypes),
+                        ...getTypeTree(args.sourceId, eventRelatedTypes),
+                        ...getTypeTree(args.targetId, eventRelatedTypes),
                     };
                     // Directly modifying childTree is pretty hacky
                     Object.assign(childTree, updateTypeTreePositions(typeTree));
                 }
                 return `Compare types ${args.sourceId} and ${args.targetId}`;
-            case "getVariancesWorker":
-                if (relatedTypes && curr.children.length === 0) {
-                    const typeTree = getTypeTree(event.args!.id, relatedTypes);
+            }
+            case "getVariancesWorker": {
+                if (!event.args) {
+                    return undefined;
+                }
+                const eventRelatedTypes = getRelatedTypesForEvent(relatedTypes, typeSources, event);
+                if (eventRelatedTypes && curr.children.length === 0) {
+                    const typeTree = getTypeTree(event.args!.id, eventRelatedTypes);
                     // Directly modifying childTree is pretty hacky
                     Object.assign(childTree, updateTypeTreePositions(typeTree));
                 }
                 return `Determine variance of type ${event.args!.id}`;
+            }
             default:
-                if (event.cat === "check" && event.args && event.args.pos && event.args.end) {
+                if (event.cat === "check" && event.args && event.args.pos && event.args.end && currentFile) {
                     const currentFileClause = showCurrentFile
                         ? ` in ${formatPath(currentFile!)}`
                         : "";


### PR DESCRIPTION
Fixes #47

1. Per-(pid,tid) stacks. The parser and hot-path tree builder previously assumed one stack. Now keyed by ${pid}:${tid} so multi-threaded traces parse correctly.
2. TypeSource abstraction. Replaced the old typesPath: string single-file assumption with TypeSource = { typesPath, checkerId? } and a TypeSources array. Routing logic: if 
there's one source, use it; otherwise look up by event.args.checkerId. Keys for the related-types map are namespaced (path: vs checkerId:N:path:) to avoid collisions.
3. Legend support. analyze-trace-dir reads legend.json if present and coalesces entries by (configFilePath, tracePath) into a single project with multiple type sources.